### PR TITLE
Add a no-op configuration for Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,12 @@
+pipeline {
+    agent none
+
+    stages {
+        stage('Build') {
+            agent any
+            steps {
+                sh 'exit 0'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since we've discovered that pushing built images from Circle to OpenShift is going to be a pain, let's start this repo off with a passing build pipeline. The pipeline should be adjusted to test any and all code added to the repo.