### PR TITLE
use a fixture to populate a table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ DOCKER_SQITCH_IMAGE=wenzowski/sqitch
 DOCKER_SQITCH_TAG=0.9999
 DOCKER_POSTGRES_IMAGE=wenzowski/postgres
 DOCKER_POSTGRES_TAG=11.2
+CURRENT_DIR=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 
 test:
 	@@$(MAKE) -s $(MAKEFLAGS) createdb;
@@ -28,7 +29,7 @@ deploy:
 
 prove:
 	# Run test suite using pg_prove
-	@@${PG_PROVE} -v -d ${TEST_DB} test/*
+	@@${PG_PROVE} -S CURRENT_DIR="${CURRENT_DIR}" -v -d ${TEST_DB} test/*
 .PHONY: test
 
 revert:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ DOCKER_SQITCH_IMAGE=wenzowski/sqitch
 DOCKER_SQITCH_TAG=0.9999
 DOCKER_POSTGRES_IMAGE=wenzowski/postgres
 DOCKER_POSTGRES_TAG=11.2
-CURRENT_DIR=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 
 test:
 	@@$(MAKE) -s $(MAKEFLAGS) createdb;
@@ -29,7 +28,7 @@ deploy:
 
 prove:
 	# Run test suite using pg_prove
-	@@${PG_PROVE} -S CURRENT_DIR="${CURRENT_DIR}" -v -d ${TEST_DB} test/*
+	@@${PG_PROVE} -v -d ${TEST_DB} test/*
 .PHONY: test
 
 revert:

--- a/test/fixture/csv_import_fixture.csv
+++ b/test/fixture/csv_import_fixture.csv
@@ -1,0 +1,1 @@
+"value exists"

--- a/test/variable_test.sql
+++ b/test/variable_test.sql
@@ -9,8 +9,7 @@ select plan(1);
 create schema ggircs_test_fixture;
 set search_path to ggircs_test_fixture,public;
 create table csv_import_fixture (csv_column_fixture text);
-\set csv_import_fixture_file :CURRENT_DIR '/test/fixture/csv_import_fixture.csv'
-copy csv_import_fixture from :'csv_import_fixture_file' delimiter ',' csv;
+\copy csv_import_fixture from './test/fixture/csv_import_fixture.csv' delimiter ',' csv;
 select set_eq(
     'select * from csv_import_fixture',
     array[ 'value exists' ]

--- a/test/variable_test.sql
+++ b/test/variable_test.sql
@@ -1,0 +1,22 @@
+set client_min_messages to warning;
+create extension if not exists pgtap;
+reset client_min_messages;
+
+begin;
+
+select plan(1);
+
+create schema ggircs_test_fixture;
+set search_path to ggircs_test_fixture,public;
+create table csv_import_fixture (csv_column_fixture text);
+\set csv_import_fixture_file :CURRENT_DIR '/test/fixture/csv_import_fixture.csv'
+copy csv_import_fixture from :'csv_import_fixture_file' delimiter ',' csv;
+select set_eq(
+    'select * from csv_import_fixture',
+    array[ 'value exists' ]
+);
+
+select * from finish();
+
+rollback;
+


### PR DESCRIPTION
this is an example of how to get a relative path to a fixture file passed into the test suite as an absolute path that the database can read