### PR TITLE
(wip) add example integration tests and `make prove_integration`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GIT=git
 AWK=awk
 PSQL=psql -h localhost
 TEST_DB=ggircs_test
+DEV_DB=ggircs_dev
 PG_PROVE=pg_prove -h localhost
 DOCKER_SQITCH_IMAGE=wenzowski/sqitch
 DOCKER_SQITCH_TAG=0.9999
@@ -33,12 +34,17 @@ deploy:
 prove_style:
 	# Run style-related test suite on all objects in db using pg_prove
 	@@${PG_PROVE} -v -d ${TEST_DB} test/style/*_test.sql
-.PHONY: prove
+.PHONY: prove_style
 
 prove_unit:
 	# Run unit test suite using pg_prove
 	@@${PG_PROVE} -v -d ${TEST_DB} test/unit/*_test.sql
-.PHONY: test
+.PHONY: prove_unit
+
+prove_integration:
+	# Run unit test suite using pg_prove
+	@@${PG_PROVE} -v -d ${DEV_DB} test/integration/*_test.sql
+.PHONY: prove_integration
 
 revert:
 	# Revert all changes to ${TEST_DB} using sqitch

--- a/test/integration/ggircs_swrs_ghgr_import_test.sql
+++ b/test/integration/ggircs_swrs_ghgr_import_test.sql
@@ -1,0 +1,125 @@
+set client_min_messages to warning;
+create extension if not exists pgtap;
+reset client_min_messages;
+
+begin;
+select plan(8);
+
+select results_eq($$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select distinct tag.name
+    from x,
+         xmltable('/*' passing xml_file columns name text path 'name(.)') as tag
+    order by tag.name;
+  $$,
+  ARRAY['ReportData'::text],
+  'The only allowable root tag is <ReportData>'
+);
+
+select results_eq($$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select count(tag)
+    from x,
+         xmltable('/ReportData' passing xml_file columns xml_hunk text path '.') as tag;
+  $$, $$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select count(tag)
+    from x,
+         xmltable('//ReportData' passing xml_file columns xml_hunk text path '.') as tag;
+  $$,
+  'There are no <ReportData> tags anywhere except the top level'
+);
+
+select results_eq($$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select distinct tag.name
+    from x,
+         xmltable('/ReportData/*' passing xml_file columns name text path 'name(.)') as tag
+    order by tag.name;
+  $$,
+  ARRAY[
+    'ActivityData'::text,
+    'LegalSubmissionData'::text,
+    'OperationalWorkerReport'::text,
+    'OperationalWorkerReports'::text,
+    'RegistrationData'::text,
+    'ReportDetails'::text,
+    'SaleClosePurchase'::text,
+    'VerifyTombstone'::text
+    ],
+  'The allowable <ReportData> child tags have not changed'
+);
+
+select results_eq($$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select count(tag)
+    from x,
+         xmltable('/ReportData/ActivityData' passing xml_file columns xml_hunk text path '.') as tag;
+  $$, $$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select count(tag)
+    from x,
+         xmltable('//ActivityData' passing xml_file columns xml_hunk text path '.') as tag;
+  $$,
+  'The <ActivityData> tag is always a child of <ReportData>'
+);
+
+select results_eq($$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select count(tag)
+    from x,
+         xmltable('/ReportData/LegalSubmissionData' passing xml_file columns xml_hunk text path '.') as tag;
+  $$, $$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select count(tag)
+    from x,
+         xmltable('//LegalSubmissionData' passing xml_file columns xml_hunk text path '.') as tag;
+  $$,
+  'The <LegalSubmissionData> tag is always a child of <ReportData>'
+);
+
+select results_eq($$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select count(tag)
+    from x,
+         xmltable('/ReportData/OperationalWorkerReport|/ReportData/OperationalWorkerReports/OperationalWorkerReport' passing xml_file columns xml_hunk text path '.') as tag;
+  $$, $$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select count(tag)
+    from x,
+         xmltable('//OperationalWorkerReport' passing xml_file columns xml_hunk text path '.') as tag;
+  $$,
+  'The <OperationalWorkerReport> tag is always either a child of <ReportData> or <OperationalWorkerReports>'
+);
+
+select results_eq($$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select count(tag)
+    from x,
+         xmltable('/ReportData/OperationalWorkerReports' passing xml_file columns xml_hunk text path '.') as tag;
+  $$, $$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select count(tag)
+    from x,
+         xmltable('//OperationalWorkerReports' passing xml_file columns xml_hunk text path '.') as tag;
+  $$,
+  'The <OperationalWorkerReports> tag is always a child of <ReportData>'
+);
+
+select results_eq($$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select count(tag)
+    from x,
+         xmltable('/ReportData/RegistrationData' passing xml_file columns xml_hunk text path '.') as tag;
+  $$, $$
+    with x as (select id, xml_file from ggircs_swrs.ghgr_import)
+    select count(tag)
+    from x,
+         xmltable('//RegistrationData' passing xml_file columns xml_hunk text path '.') as tag;
+  $$,
+  'The <RegistrationData> tag is always a child of <ReportData>'
+);
+
+
+select finish();
+rollback;


### PR DESCRIPTION
By asserting that our assumptions about the imported xml data continue to be true, this checks will inform us when the shape of the data provided by ECCC changes in the future.