### PR TITLE
final report view

### DIFF
--- a/deploy/materialized_view_final_report.sql
+++ b/deploy/materialized_view_final_report.sql
@@ -1,0 +1,40 @@
+-- Deploy ggircs:materialized_view_final_report to pg
+-- requires: materialized_view_facility
+
+begin;
+
+create materialized view ggircs_swrs.final_report as (
+  with final_report as (
+    with x as (
+      select report.swrs_report_id,
+         min(swrs_report_history_id) as swrs_auth_history_id
+      from ggircs_swrs.report
+      where status = 'Submitted'
+      group by swrs_report_id
+    )
+    select report.*
+    from ggircs_swrs.report
+        inner join x
+            on report.swrs_report_id = x.swrs_report_id
+            and report.swrs_report_history_id = x.swrs_auth_history_id
+  ),
+  report_facility as (
+    select
+        report.id as report_id,
+        facility.id as facility_id
+    from final_report as report
+    left outer join ggircs_swrs.facility on report.id = ggircs_swrs.facility.ghgr_import_id
+    where report.status = 'Submitted'
+    order by report.swrs_report_id desc, report.swrs_report_history_id asc
+  )
+  select * from report_facility
+ -- select count(report_id), count(distinct report_id) from report_facility
+) with no data;
+
+create unique index ggircs_final_report_primary_key on ggircs_swrs.final_report (report_id);
+
+comment on materialized view ggircs_swrs.final_report is 'The view showing the latest submitted report by a facility';
+comment on column ggircs_swrs.final_report.report_id is 'The foreign key refrencing ggircs_swrs.report';
+comment on column ggircs_swrs.final_report.facility_id is 'The foreign key refrencing ggircs_swrs.facility';
+
+commit;

--- a/deploy/materialized_view_final_report.sql
+++ b/deploy/materialized_view_final_report.sql
@@ -4,37 +4,28 @@
 begin;
 
 create materialized view ggircs_swrs.final_report as (
-  with final_report as (
-    with x as (
-      select report.swrs_report_id,
-         min(swrs_report_history_id) as swrs_auth_history_id
-      from ggircs_swrs.report
-      where status = 'Submitted'
-      group by swrs_report_id
-    )
-    select report.*
+  with _report as (
+    select *,
+           row_number() over (
+             partition by swrs_report_id
+             order by
+               submission_date desc,
+               ghgr_import_id desc
+             ) as _history_id
     from ggircs_swrs.report
-        inner join x
-            on report.swrs_report_id = x.swrs_report_id
-            and report.swrs_report_history_id = x.swrs_auth_history_id
-  ),
-  report_facility as (
-    select
-        report.id as report_id,
-        facility.id as facility_id
-    from final_report as report
-    left outer join ggircs_swrs.facility on report.id = ggircs_swrs.facility.ghgr_import_id
-    where report.status = 'Submitted'
-    order by report.swrs_report_id desc, report.swrs_report_history_id asc
+    where submission_date is not null
+    order by swrs_report_id
   )
-  select * from report_facility
- -- select count(report_id), count(distinct report_id) from report_facility
+  select swrs_report_id, ghgr_import_id
+  from _report
+  where _history_id = 1
+  order by swrs_report_id asc
 ) with no data;
 
-create unique index ggircs_final_report_primary_key on ggircs_swrs.final_report (report_id);
+create unique index ggircs_final_report_primary_key on ggircs_swrs.final_report (swrs_report_id, ghgr_import_id);
 
-comment on materialized view ggircs_swrs.final_report is 'The view showing the latest submitted report by a facility';
-comment on column ggircs_swrs.final_report.report_id is 'The foreign key refrencing ggircs_swrs.report';
-comment on column ggircs_swrs.final_report.facility_id is 'The foreign key refrencing ggircs_swrs.facility';
+comment on materialized view ggircs_swrs.final_report is 'The view showing the latest submitted report by ggircs_swrs.report.id';
+comment on column ggircs_swrs.final_report.swrs_report_id is 'The foreign key referencing ggircs_swrs.report.id';
+comment on column ggircs_swrs.final_report.ghgr_import_id is 'The foreign key referencing ggircs_swrs.ghgr_import.id';
 
 commit;

--- a/revert/materialized_view_final_report.sql
+++ b/revert/materialized_view_final_report.sql
@@ -1,0 +1,7 @@
+-- Revert ggircs:materialized_view_final_report from pg
+
+begin;
+
+drop materialized view ggircs_swrs.final_report;
+
+commit;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -13,3 +13,4 @@ materialized_view_flat [table_ghgr_import] 2019-04-30T18:11:08Z Dylan Leard <dyl
 materialized_view_unit [materialized_view_activity] 2019-05-02T19:54:25Z Dylan Leard <dylan@button.is> # add materialized view unit to schema ggircs_swrs
 materialized_view_identifier [table_ghgr_import] 2019-04-30T23:33:13Z Dylan Leard <dylan@button.is> # add materialized view identifier to schema ggircs_swrs
 materialized_view_naics [table_ghgr_import] 2019-05-01T23:52:03Z Dylan Leard <dylan@button.is> # add materialized view naics to schema ggircs_swrs
+materialized_view_final_report [materialized_view_facility] 2019-05-03T18:47:28Z Dylan Leard <dylan@button.is> # add materialized view final_report to schema ggircs_swrs

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -13,4 +13,4 @@ materialized_view_flat [table_ghgr_import] 2019-04-30T18:11:08Z Dylan Leard <dyl
 materialized_view_unit [materialized_view_activity] 2019-05-02T19:54:25Z Dylan Leard <dylan@button.is> # add materialized view unit to schema ggircs_swrs
 materialized_view_identifier [table_ghgr_import] 2019-04-30T23:33:13Z Dylan Leard <dylan@button.is> # add materialized view identifier to schema ggircs_swrs
 materialized_view_naics [table_ghgr_import] 2019-05-01T23:52:03Z Dylan Leard <dylan@button.is> # add materialized view naics to schema ggircs_swrs
-materialized_view_final_report [materialized_view_facility] 2019-05-03T18:47:28Z Dylan Leard <dylan@button.is> # add materialized view final_report to schema ggircs_swrs
+materialized_view_final_report [materialized_view_report] 2019-05-03T18:47:28Z Dylan Leard <dylan@button.is> # add materialized view final_report to schema ggircs_swrs

--- a/test/unit/materialized_view_final_report_test.sql
+++ b/test/unit/materialized_view_final_report_test.sql
@@ -1,0 +1,33 @@
+set client_encoding = 'utf-8';
+set client_min_messages = warning;
+create extension if not exists pgtap;
+reset client_min_messages;
+
+begin;
+select plan(7);
+
+select has_materialized_view(
+    'ggircs_swrs', 'final_report',
+    'ggircs_swrs.final_report should be a materialized view'
+);
+
+select has_index(
+    'ggircs_swrs', 'final_report', 'ggircs_final_report_primary_key',
+    'ggircs_swrs.final_report should have a primary key'
+);
+
+select columns_are('ggircs_swrs'::name, 'final_report'::name, array[
+    'report_id'::name,
+    'facility_id'::name
+]);
+
+--  select has_column(       'ggircs_swrs', 'final_report', 'report_id', 'final_report.report_id column should exist');
+select col_type_is(      'ggircs_swrs', 'final_report', 'report_id', 'bigint', 'final_report.report_id column should be type bigint');
+select col_hasnt_default('ggircs_swrs', 'final_report', 'report_id', 'final_report.report_id column should not have a default value');
+
+--  select has_column(       'ggircs_swrs', 'final_report', 'facility_id_', 'final_report.facility_id column should exist');
+select col_type_is(      'ggircs_swrs', 'final_report', 'facility_id', 'bigint', 'final_report.facility_id column should be type bigint');
+select col_hasnt_default('ggircs_swrs', 'final_report', 'facility_id', 'final_report.facility_id column should not have a default value');
+
+select * from finish();
+rollback;

--- a/test/unit/materialized_view_final_report_test.sql
+++ b/test/unit/materialized_view_final_report_test.sql
@@ -4,7 +4,7 @@ create extension if not exists pgtap;
 reset client_min_messages;
 
 begin;
-select plan(7);
+select plan(9);
 
 select has_materialized_view(
     'ggircs_swrs', 'final_report',
@@ -17,17 +17,89 @@ select has_index(
 );
 
 select columns_are('ggircs_swrs'::name, 'final_report'::name, array[
-    'report_id'::name,
-    'facility_id'::name
+    'swrs_report_id'::name,
+    'ghgr_import_id'::name
 ]);
 
---  select has_column(       'ggircs_swrs', 'final_report', 'report_id', 'final_report.report_id column should exist');
-select col_type_is(      'ggircs_swrs', 'final_report', 'report_id', 'bigint', 'final_report.report_id column should be type bigint');
-select col_hasnt_default('ggircs_swrs', 'final_report', 'report_id', 'final_report.report_id column should not have a default value');
+--  select has_column(       'ggircs_swrs', 'final_report', 'swrs_report_id', 'final_report.swrs_report_id column should exist');
+select col_type_is(      'ggircs_swrs', 'final_report', 'swrs_report_id', 'numeric(1000,0)', 'final_report.swrs_report_id column should be type bigint');
+select col_hasnt_default('ggircs_swrs', 'final_report', 'swrs_report_id', 'final_report.swrs_report_id column should not have a default value');
 
---  select has_column(       'ggircs_swrs', 'final_report', 'facility_id_', 'final_report.facility_id column should exist');
-select col_type_is(      'ggircs_swrs', 'final_report', 'facility_id', 'bigint', 'final_report.facility_id column should be type bigint');
-select col_hasnt_default('ggircs_swrs', 'final_report', 'facility_id', 'final_report.facility_id column should not have a default value');
+--  select has_column(       'ggircs_swrs', 'final_report', 'ghgr_import_id', 'final_report.ghgr_import_id column should exist');
+select col_type_is(      'ggircs_swrs', 'final_report', 'ghgr_import_id', 'integer', 'final_report.ghgr_import_id column should be type bigint');
+select col_hasnt_default('ggircs_swrs', 'final_report', 'ghgr_import_id', 'final_report.ghgr_import_id column should not have a default value');
+
+-- Setup fixture
+insert into ggircs_swrs.ghgr_import (imported_at, xml_file) VALUES
+('2018-09-29T11:55:39.423', $$
+<ReportData xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <ReportDetails>
+    <ReportID>800855555</ReportID>
+    <PrepopReportID></PrepopReportID>
+    <ReportType>R7</ReportType>
+    <FacilityId>666</FacilityId>
+    <OrganisationId>1337</OrganisationId>
+    <ReportingPeriodDuration>1999</ReportingPeriodDuration>
+    <ReportStatus>
+      <Status>Completed</Status>
+      <Version>3</Version>
+      <LastModifiedBy>Donny Donaldson McDonaldface</LastModifiedBy>
+      <LastModifiedDate>2018-09-28T11:55:39.423</LastModifiedDate>
+    </ReportStatus>
+  </ReportDetails>
+</ReportData>
+$$), ('2018-10-15T12:35:27.226', $$
+<ReportData xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <ReportDetails>
+    <ReportID>800855555</ReportID>
+    <PrepopReportID></PrepopReportID>
+    <ReportType>R7</ReportType>
+    <FacilityId>666</FacilityId>
+    <OrganisationId>1337</OrganisationId>
+    <ReportingPeriodDuration>1999</ReportingPeriodDuration>
+    <ReportStatus>
+      <Status>Submitted</Status>
+      <SubmissionDate>2018-10-14T12:35:27.226</SubmissionDate>
+      <Version>3</Version>
+      <LastModifiedBy>Donny Donaldson McDonaldface</LastModifiedBy>
+      <LastModifiedDate>2018-10-14T12:35:27.226</LastModifiedDate>
+    </ReportStatus>
+  </ReportDetails>
+</ReportData>
+$$), ('2018-11-15T12:35:27.226', $$
+<ReportData xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <ReportDetails>
+    <ReportID>800855555</ReportID>
+    <PrepopReportID></PrepopReportID>
+    <ReportType>R7</ReportType>
+    <FacilityId>666</FacilityId>
+    <OrganisationId>1337</OrganisationId>
+    <ReportingPeriodDuration>1999</ReportingPeriodDuration>
+    <ReportStatus>
+      <Status>Archived</Status>
+      <SubmissionDate>2018-11-14T12:35:27.226</SubmissionDate>
+      <Version>3</Version>
+      <LastModifiedBy>Donny Donaldson McDonaldface</LastModifiedBy>
+      <LastModifiedDate>2018-11-14T12:35:27.226</LastModifiedDate>
+    </ReportStatus>
+  </ReportDetails>
+</ReportData>$$
+);
+
+-- Ensure fixture is processed correctly
+refresh materialized view ggircs_swrs.report with data;
+refresh materialized view ggircs_swrs.final_report with data;
+
+select results_eq(
+  'select swrs_report_id from ggircs_swrs.final_report',
+  array['800855555'::numeric],
+  'ggircs_swrs.final_report.swrs_report_id should contain one single value'
+);
+select results_eq(
+  $$select ghgr_import_id from ggircs_swrs.final_report$$,
+  $$select ghgr_import_id from ggircs_swrs.report where status = 'Archived'$$,
+  'ggircs_swrs.final_report.ghgr_import_id should refer to the correct version'
+);
 
 select * from finish();
 rollback;

--- a/verify/materialized_view_final_report.sql
+++ b/verify/materialized_view_final_report.sql
@@ -1,0 +1,7 @@
+-- Verify ggircs:materialized_view_final_report on pg
+
+begin;
+
+select * from ggircs_swrs.final_report where false;
+
+rollback;


### PR DESCRIPTION
continuation of #30 with prior commits squashed

This view identifies the final `ghgr_import_id` for every `swrs_report_id` so queries can be constructed that use only the latest version of an xml report from the Single Window Reporting System.