### PR TITLE
Makefile uses cpanfile + extra checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ install_pgtap: pgtap
 
 ifeq (error,${shell /bin/test -w ${PG_SHAREDIR}/extension || echo error})
 	@@echo "FATAL: The current user does not have permission to write to ${PG_SHAREDIR}/extension and install pgTAP.\
-	It needs to be installed by a user having write access to that directory, e.g. with 'sudo make -C pgtap install'" && exit 1
+ It needs to be installed by a user having write access to that directory, e.g. with 'sudo make -C pgtap install'" && exit 1
 else
 	@@$(MAKE) -C pgtap -s $(MAKEFLAGS) install
 endif

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PERL_MIN_VERSION=5.10
 CPAN=cpan
 CPANM=cpanm
 SQITCH=sqitch
+SQITCH_MIN_VERSION=0.97
 GREP=grep
 GIT=git
 AWK=awk
@@ -163,7 +164,12 @@ install_cpandeps:
 	${CPANM} --installdeps .
 .PHONY: install_cpandeps
 
-install: install_cpanm install_cpandeps install_pgtap
+postinstall_check:
+	@@printf '%s\n%s\n' "${SQITCH_MIN_VERSION}" $$(echo $$(${SQITCH} --version) | cut -d " " -f 3) | sort -CV ||\
+ 	(echo "FATAL: ${SQITCH} version should be at least ${SQITCH_MIN_VERSION}. Make sure the ${SQITCH} executable installed by cpanminus is available has the highest priority in the PATH" && exit 1);
+.PHONY: postinstall_check
+
+install: install_cpanm install_cpandeps postinstall_check install_pgtap 
 .PHONY: install
 
 docker_build_sqitch:

--- a/Makefile
+++ b/Makefile
@@ -134,20 +134,20 @@ verify: verify_installed verify_pg_server
 pgtap:
 	# clone the source for pgTAP
 	@@${GIT} clone https://github.com/theory/pgtap.git && \
-		cd pgtap && \
+		pushd pgtap && \
 		${GIT} checkout v1.0.0;
 
-#use pushd/popd
 install_pgtap: pgtap
-	# install pgTAP into postgres
-	@@cd pgtap && \
-		$(MAKE) -s $(MAKEFLAGS) && \
-		$(MAKE) -s $(MAKEFLAGS) installcheck;
+	${info install pgTAP into postgres}
+	@@$(MAKE) -C pgtap -s $(MAKEFLAGS)
+	@@$(MAKE) -C pgtap -s $(MAKEFLAGS) installcheck
 
-	@@/bin/test -w ${PG_SHAREDIR}/extension && \
-		cd pgtap && $(MAKE) -s $(MAKEFLAGS) install || \
-		${error The current user does not have permission to write to ${PG_SHAREDIR}/extension and install pgTAP.\
-		It needs to be installed by a user having write access to that directory, e.g. with 'cd pgtap && sudo make install'}	
+ifeq (error,${shell /bin/test -w ${PG_SHAREDIR}/extension || echo error})
+	@@echo "FATAL: The current user does not have permission to write to ${PG_SHAREDIR}/extension and install pgTAP.\
+	It needs to be installed by a user having write access to that directory, e.g. with 'cd pgtap && sudo make install'" && exit 1
+else
+	@@$(MAKE) -C pgtap -s $(MAKEFLAGS) install
+endif
 .PHONY: install_pgtap
 
 

--- a/Makefile
+++ b/Makefile
@@ -85,16 +85,16 @@ verify_installed:
 	@@${GIT} --version | ${AWK} '{print $$NF}';
 	# ensure psql is installed
 	@@${PSQL} --version | ${AWK} '{print $$NF}';
-	# ensure the correct role exist in postgres
-ifeq (1,${shell ${PSQL} -qAtc "select count(*) from pg_user where usename='${PG_ROLE}' and usesuper=true"})
-	@@echo 'A postgres role with the name "${PG_ROLE}" must exist and have the SUPERUSER privilege.'
-	@@exit 1
-endif
 .PHONY: verify_installed
 
 verify_ready:
 	# ensure postgres is online
 	@@${PSQL} -tc 'show server_version;' | ${AWK} '{print $$NF}';
+	# ensure the correct role exist in postgres
+ifeq (1,${shell ${PSQL} -qAtc "select count(*) from pg_user where usename='${PG_ROLE}' and usesuper=true"})
+	@@echo 'A postgres role with the name "${PG_ROLE}" must exist and have the SUPERUSER privilege.'
+	@@exit 1
+endif
 .PHONY: verify_ready
 
 verify: verify_installed verify_ready

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ install_pgtap: pgtap
 
 ifeq (error,${shell /bin/test -w ${PG_SHAREDIR}/extension || echo error})
 	@@echo "FATAL: The current user does not have permission to write to ${PG_SHAREDIR}/extension and install pgTAP.\
-	It needs to be installed by a user having write access to that directory, e.g. with 'cd pgtap && sudo make install'" && exit 1
+	It needs to be installed by a user having write access to that directory, e.g. with 'sudo make -C pgtap install'" && exit 1
 else
 	@@$(MAKE) -C pgtap -s $(MAKEFLAGS) install
 endif

--- a/Readme.md
+++ b/Readme.md
@@ -9,14 +9,16 @@ GGIRCS
 ------------
 > Clone repository
 > In terminal:
-  - If needed, run `make install` to set up a development environment on OS X
   - Run `make verify` to ensure minimum required versions of all dependencies are installed and postgres is online
+  - Run `make install` to set up a development environment
+  - If needed, create a test database using `$ createdb ggircs_test`
   - Run `make test` to execute all pgTAP-based tests against a `ggircs_test` database
+  - If needed, create a development database using `$ createdb ggircs_dev`
   - Run `sqitch deploy` to deploy to a `ggircs_dev` database
 
 ## Using Sqitch
 ------------
-If you're new to Sqitch, the best place to start is with [the tutuorial](https://github.com/sqitchers/sqitch/blob/master/lib/sqitchtutorial.pod) and other [docs](https://sqitch.org/docs/).
+If you're new to Sqitch, the best place to start is with [the tutorial](https://github.com/sqitchers/sqitch/blob/master/lib/sqitchtutorial.pod) and other [docs](https://sqitch.org/docs/).
 
 > **Add Schema**
 > - sqitch add schema_[schema_name]
@@ -28,9 +30,11 @@ If you're new to Sqitch, the best place to start is with [the tutuorial](https:/
 ------------
 1. [PostgreSQL](http://www.postgresql.org/)
 
-    10 or higher recommended. Usually available via your distribution's
-    package system. Binaries and source are also available
-    [for download](http://www.postgresql.org/download/).
+- 10 or higher recommended. Usually available via your distribution's package system. Binaries and source are also available [for download](http://www.postgresql.org/download/).
+
+- A role with the following options must be created:
+    - The role name is your current user name (`$ whoami`)
+    - The role has the SUPERUSER option
 
 2. [Git](http://git-scm.com)
 
@@ -38,41 +42,9 @@ If you're new to Sqitch, the best place to start is with [the tutuorial](https:/
     package system. Binaries and source are also available
     [for download](http://git-scm.com/downloads).
 
-3. [pgTAP](http://pgtap.org/)
-
-    0.92.0 or higher recommended. Download
-    [from PGXN](http://pgxn.org/dist/pgtap/) and consult its
-    [`README.md`](https://github.com/theory/pgtap/blob/master/README.md) for
-    build instructions. Also available in some packaging systems.
-
 4. [Perl](http://perl.org/)
 
     5.10.0 or higher. Included in most Unix distributions and on OS X. Windows
     users can install
     [ActivePerl](http://www.activestate.com/activeperl/downloads).
 
-5. [`pg_prove`](http://pgtap.org/pg_prove.html)
-
-    3.28 or higher recommended. Available in some packaging systems.
-    Otherwise, Download via CPAN:
-
-        cpan TAP::Parser::SourceHandler::pgTAP
-
-    ActivePerl users can use PPI:
-
-        ppm install TAP-Parser-SourceHandler-pgTAP
-
-6. [Sqitch](http://sqitch.org/)
-
-    0.97.0 or higher recommended. Install via CPAN:
-
-        cpan App::Sqitch DBD::Pg
-
-    ActivePerl users should use PPI:
-
-        ppi App-Sqitch
-
-    [Homebrew](http://brew.sh) users can use the Sqitch Tap:
-
-        brew tap sqitchers/sqitch
-        brew install sqitch --with-postgres-suppor

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,6 @@ GGIRCS
 > In terminal:
   - Run `make verify` to ensure minimum required versions of all dependencies are installed and postgres is online
   - Run `make install` to set up a development environment
-  - If needed, create a test database using `$ createdb ggircs_test`
   - Run `make test` to execute all pgTAP-based tests against a `ggircs_test` database
   - If needed, create a development database using `$ createdb ggircs_dev`
   - Run `sqitch deploy` to deploy to a `ggircs_dev` database


### PR DESCRIPTION
In Makefile:
 - `make verify` only checks dependencies that are not installed by `make install`
 - `make verify` checks that the database server contains the appropriate role
 - `make install` uses `cpanm` to install the CPAN dependencies listed in `cpanfile`
 - if `cpanm` isn't installed, `make install will install it using `cpan`
 - before installing `pgTAP` checks whether elevated privileges (or a different user) are needed. If so, warn the user that they have to run the `pgTAP` `make install` manually
 

In README:
 - updated the order of base steps (`verify` before `install`)
 - added `createdb` steps
 - do not list dependencies  that are installed by Makefile
 - added info regarding the role that must exist in postgres