### PR TITLE
Clean-up linebreaks (use $$ instead of ||)

### DIFF
--- a/deploy/function_export_mv_to_table.sql
+++ b/deploy/function_export_mv_to_table.sql
@@ -16,10 +16,10 @@ $$
   /** Create all tables from materialized views that are not being split up **/
   declare
 
-       mv_array text[] := '{report, organisation, facility, ' ||
-                       'activity, unit, identifier, naics, emission, ' ||
-                       'final_report, fuel, permit, parent_organisation, contact, ' ||
-                       'address, descriptor, measured_emission_factor}';
+       mv_array text[] := $a${report, organisation, facility,
+                       activity, unit, identifier, naics, emission,
+                       final_report, fuel, permit, parent_organisation, contact,
+                       address, descriptor, measured_emission_factor}$a$;
 
   begin
 
@@ -39,9 +39,9 @@ $$
 
         execute
           'create table ggircs.' || quote_ident(mv_array[i]) ||
-                ' as (select x.* from ggircs_swrs.' || quote_ident(mv_array[i]) ||
-                ' as x inner join ggircs_swrs.final_report as final_report ' ||
-                ' on x.ghgr_import_id = final_report.ghgr_import_id)';
+                 ' as (select x.* from ggircs_swrs.' || quote_ident(mv_array[i]) ||
+                 $a$ as x inner join ggircs_swrs.final_report as final_report
+                 on x.ghgr_import_id = final_report.ghgr_import_id)$a$;
         execute
           'alter table ggircs.' || quote_ident(mv_array[i]) ||
           ' add column id int generated always as identity primary key';
@@ -55,27 +55,28 @@ $$
 
     execute
 
-          'create table ggircs.attributable_emission ' ||
-          'as (select x.* from ggircs_swrs.emission ' ||
-          'as x inner join ggircs_swrs.final_report as final_report ' ||
-          'on x.ghgr_import_id = final_report.ghgr_import_id ' ||
-          'join ggircs_swrs.facility as facility ' ||
-          'on x.ghgr_import_id = facility.ghgr_import_id ' ||
-          'join ggircs_swrs.activity as activity ' ||
-          'on x.ghgr_import_id = activity.ghgr_import_id ' ||
-          'and x.process_idx = activity.process_idx ' ||
-          'and x.sub_process_idx = activity.sub_process_idx ' ||
-          'and x.activity_name = activity.activity_name ' ||
-          'and x.gas_type != ''CO2bioC'' '||
-          'and facility.facility_type != ''EIO'' '||
-          'and facility.facility_type != ''LFO'' '||
-          'and activity.sub_process_name not in  (''Additional Reportable Information as per WCI.352(i)(1)-(12)'',' ||
-                                   '''Additional Reportable Information as per WCI.352(i)(13)'', ' ||
-                                   '''Additional Reportable Information as per WCI.362(g)(21)'', ' ||
-                                   '''Additional information for cement and lime production facilities only (not aggregated in totals)'', ' ||
-                                   '''Additional information for cement and lime production facilities only (not aggregated intotals)'', ' ||
-                                   '''Additional information required when other activities selected are Activities in Table 2 rows 2, 4, 5 , or 6'', ' ||
-                                   '''Additional reportable information'') )';
+          $a$create table ggircs.attributable_emission
+          as (select x.* from ggircs_swrs.emission
+          as x inner join ggircs_swrs.final_report as final_report
+          on x.ghgr_import_id = final_report.ghgr_import_id
+          join ggircs_swrs.facility as facility
+          on x.ghgr_import_id = facility.ghgr_import_id
+          join ggircs_swrs.activity as activity
+          on x.ghgr_import_id = activity.ghgr_import_id
+          and x.process_idx = activity.process_idx
+          and x.sub_process_idx = activity.sub_process_idx
+          and x.activity_name = activity.activity_name
+          and x.gas_type != 'CO2bioC'
+          and facility.facility_type != 'EIO'
+          and facility.facility_type != 'LFO'
+          and activity.sub_process_name not in  ('Additional Reportable Information as per WCI.352(i)(1)-(12)',
+                                   'Additional Reportable Information as per WCI.352(i)(13)',
+                                   'Additional Reportable Information as per WCI.362(g)(21)',
+                                   'Additional information for cement and lime production facilities only (not aggregated in totals)',
+                                   'Additional information for cement and lime production facilities only (not aggregated intotals)',
+                                   'Additional information required when other activities selected are Activities in Table 2 rows 2, 4, 5 , or 6',
+                                   'Additional reportable information')
+          )$a$;
 
     execute 'alter table ggircs.attributable_emission add column id int generated always as identity primary key';
     

--- a/deploy/function_export_mv_to_table.sql
+++ b/deploy/function_export_mv_to_table.sql
@@ -12,14 +12,16 @@ begin;
 
 create or replace function ggircs_swrs.export_mv_to_table()
   returns void as
-$$
+$function$
   /** Create all tables from materialized views that are not being split up **/
   declare
 
-       mv_array text[] := $a${report, organisation, facility,
-                       activity, unit, identifier, naics, emission,
-                       final_report, fuel, permit, parent_organisation, contact,
-                       address, descriptor, measured_emission_factor}$a$;
+       mv_array text[] := $$
+                          {report, organisation, facility,
+                          activity, unit, identifier, naics, emission,
+                          final_report, fuel, permit, parent_organisation, contact,
+                          address, descriptor, measured_emission_factor}
+                          $$;
 
   begin
 
@@ -40,8 +42,8 @@ $$
         execute
           'create table ggircs.' || quote_ident(mv_array[i]) ||
                  ' as (select x.* from ggircs_swrs.' || quote_ident(mv_array[i]) ||
-                 $a$ as x inner join ggircs_swrs.final_report as final_report
-                 on x.ghgr_import_id = final_report.ghgr_import_id)$a$;
+                 $$ as x inner join ggircs_swrs.final_report as final_report
+                 on x.ghgr_import_id = final_report.ghgr_import_id)$$;
         execute
           'alter table ggircs.' || quote_ident(mv_array[i]) ||
           ' add column id int generated always as identity primary key';
@@ -55,7 +57,8 @@ $$
 
     execute
 
-          $a$create table ggircs.attributable_emission
+          $$
+          create table ggircs.attributable_emission
           as (select x.* from ggircs_swrs.emission
           as x inner join ggircs_swrs.final_report as final_report
           on x.ghgr_import_id = final_report.ghgr_import_id
@@ -76,7 +79,7 @@ $$
                                    'Additional information for cement and lime production facilities only (not aggregated intotals)',
                                    'Additional information required when other activities selected are Activities in Table 2 rows 2, 4, 5 , or 6',
                                    'Additional reportable information')
-          )$a$;
+          )$$;
 
     execute 'alter table ggircs.attributable_emission add column id int generated always as identity primary key';
     
@@ -392,6 +395,6 @@ $$
 
   end;
 
-$$ language plpgsql volatile ;
+$function$ language plpgsql volatile ;
 
 commit;

--- a/deploy/materialized_view_parent_organisation.sql
+++ b/deploy/materialized_view_parent_organisation.sql
@@ -36,4 +36,3 @@ comment on column ggircs_swrs.parent_organisation.business_legal_name is 'The le
 comment on column ggircs_swrs.parent_organisation.website is 'The website for this parent organisation';
 
 commit;
-

--- a/test/unit/function_export_mv_to_table_test.sql
+++ b/test/unit/function_export_mv_to_table_test.sql
@@ -785,11 +785,13 @@ select tables_are('ggircs'::name, ARRAY[
     'descriptor'::name,
     'measured_emission_factor'::name
     ],
-    $$Schema ggircs has tables [
+    $$
+    Schema ggircs has tables [
                              report, organisation, facility, activity,
                              unit, identifier, naics. emission, attributable_emission, final_report,
                              fuel, permit, parent_organisation, contact, address
-                             descriptor, measured_emission_factor $$
+                             descriptor, measured_emission_factor
+    $$
 );
 
 -- Test all tables have primary key
@@ -854,10 +856,10 @@ select is_empty($$select * from ggircs.attributable_emission where gas_type='CO2
 -- Test validity of FK relations
 -- Emission -> Fuel
 select results_eq(
-    $$select distinct(fuel.ghgr_import_id) from ggircs.emission
-      join ggircs.fuel
-      on
-        emission.fuel_id = fuel.id
+    $$
+    select distinct(fuel.ghgr_import_id) from ggircs.emission
+    join ggircs.fuel
+    on emission.fuel_id = fuel.id
     $$,
 
     'select distinct(ghgr_import_id) from ggircs.fuel',
@@ -880,10 +882,10 @@ select results_eq(
 
 -- Fuel -> Unit
 select results_eq(
-    $$select distinct(fuel.ghgr_import_id) from ggircs.fuel
-      join ggircs.unit
-      on
-        fuel.unit_id = unit.id
+    $$
+    select distinct(fuel.ghgr_import_id) from ggircs.fuel
+    join ggircs.unit
+    on fuel.unit_id = unit.id
     $$,
 
     'select distinct(ghgr_import_id) from ggircs.unit',
@@ -893,10 +895,10 @@ select results_eq(
 
 -- Unit -> Activity
 select results_eq(
-    $$select distinct(activity.ghgr_import_id) from ggircs.unit
-      join ggircs.activity
-      on
-        unit.activity_id = activity.id
+    $$
+    select distinct(activity.ghgr_import_id) from ggircs.unit
+    join ggircs.activity
+    on unit.activity_id = activity.id
     $$,
 
     'select distinct(ghgr_import_id) from ggircs.activity',
@@ -906,10 +908,10 @@ select results_eq(
 
 -- Descriptor -> Activity
 select results_eq(
-    $$select distinct(activity.ghgr_import_id) from ggircs.descriptor
-      join ggircs.activity
-      on
-        descriptor.activity_id = activity.id
+    $$
+    select distinct(activity.ghgr_import_id) from ggircs.descriptor
+    join ggircs.activity
+    on descriptor.activity_id = activity.id
     $$,
 
     'select distinct(ghgr_import_id) from ggircs.activity',
@@ -919,11 +921,12 @@ select results_eq(
 
 -- Activity -> Report
 select results_eq(
-    $$select distinct(report.ghgr_import_id) from ggircs.activity
-      join ggircs.report
-      on
-        activity.report_id = report.id
-        order by report.ghgr_import_id asc
+    $$
+    select distinct(report.ghgr_import_id) from ggircs.activity
+    join ggircs.report
+    on
+      activity.report_id = report.id
+      order by report.ghgr_import_id asc
     $$,
 
     'select distinct(ghgr_import_id) from ggircs.report order by ghgr_import_id asc',
@@ -933,10 +936,10 @@ select results_eq(
 
 -- Address -> Organisation
 select results_eq(
-    $$select distinct(organisation.ghgr_import_id) from ggircs.address
-      join ggircs.organisation
-      on
-        address.organisation_id = organisation.id
+    $$
+    select distinct(organisation.ghgr_import_id) from ggircs.address
+    join ggircs.organisation
+    on address.organisation_id = organisation.id
     $$,
 
     'select ghgr_import_id from ggircs.organisation',
@@ -946,10 +949,10 @@ select results_eq(
 
 -- Address -> Parent Organisation
 select results_eq(
-    $$select distinct(parent_organisation.ghgr_import_id) from ggircs.address
-      join ggircs.parent_organisation
-      on
-        address.parent_organisation_id = parent_organisation.id
+    $$
+    select distinct(parent_organisation.ghgr_import_id) from ggircs.address
+    join ggircs.parent_organisation
+    on address.parent_organisation_id = parent_organisation.id
     $$,
 
     'select ghgr_import_id from ggircs.parent_organisation',
@@ -959,10 +962,10 @@ select results_eq(
 
 -- Contact -> Address
 select results_eq(
-    $$select distinct(address.ghgr_import_id) from ggircs.contact
-      join ggircs.address
-      on
-        contact.address_id = address.id
+    $$
+    select distinct(address.ghgr_import_id) from ggircs.contact
+    join ggircs.address
+    on contact.address_id = address.id
     $$,
 
     'select distinct(ghgr_import_id) from ggircs.address',
@@ -972,10 +975,10 @@ select results_eq(
 
 -- Organisation -> Parent Organisation
 select results_eq(
-    $$select distinct(parent_organisation.ghgr_import_id) from ggircs.organisation
-      join ggircs.parent_organisation
-      on
-        organisation.parent_organisation_id = parent_organisation.id
+    $$
+    select distinct(parent_organisation.ghgr_import_id) from ggircs.organisation
+    join ggircs.parent_organisation
+    on organisation.parent_organisation_id = parent_organisation.id
     $$,
 
     'select ghgr_import_id from ggircs.parent_organisation',
@@ -985,11 +988,12 @@ select results_eq(
 
 -- Attributable Emission -> Fuel
 select results_eq(
-    $$select fuel.fuel_type from ggircs.attributable_emission
-      join ggircs.fuel
-      on
-        attributable_emission.fuel_id = fuel.id
-        order by fuel.ghgr_import_id
+    $$
+    select fuel.fuel_type from ggircs.attributable_emission
+    join ggircs.fuel
+    on
+      attributable_emission.fuel_id = fuel.id
+      order by fuel.ghgr_import_id
     $$,
 
     'select fuel_type from ggircs.fuel where ghgr_import_id=2 and fuel_idx = 1',
@@ -999,11 +1003,12 @@ select results_eq(
 
 -- Activity -> Facility
 select results_eq(
-    $$select distinct(facility.ghgr_import_id) from ggircs.activity
-      join ggircs.facility
-      on
-        activity.facility_id = facility.id
-        order by ghgr_import_id
+    $$
+    select distinct(facility.ghgr_import_id) from ggircs.activity
+    join ggircs.facility
+    on
+      activity.facility_id = facility.id
+      order by ghgr_import_id
     $$,
 
     'select ghgr_import_id from ggircs.facility order by ghgr_import_id',
@@ -1013,11 +1018,12 @@ select results_eq(
 
 -- Facility -> Report
 select results_eq(
-    $$select report.swrs_facility_id from ggircs.facility
-      join ggircs.report
-      on
-        facility.report_id = report.id
-        order by report.ghgr_import_id
+    $$
+    select report.swrs_facility_id from ggircs.facility
+    join ggircs.report
+    on
+      facility.report_id = report.id
+      order by report.ghgr_import_id
     $$,
 
     'select swrs_facility_id from ggircs.report order by ghgr_import_id',
@@ -1027,11 +1033,12 @@ select results_eq(
 
 -- Address -> Facility
 select results_eq(
-    $$select distinct(facility.ghgr_import_id) from ggircs.address
-      join ggircs.facility
-      on
-        address.facility_id = facility.id
-        order by ghgr_import_id
+    $$
+    select distinct(facility.ghgr_import_id) from ggircs.address
+    join ggircs.facility
+    on
+      address.facility_id = facility.id
+      order by ghgr_import_id
     $$,
 -- --
     'select ghgr_import_id from ggircs.facility order by ghgr_import_id',
@@ -1041,11 +1048,12 @@ select results_eq(
 
 -- Contact -> Facility
 select results_eq(
-    $$select distinct(facility.ghgr_import_id) from ggircs.contact
-      join ggircs.facility
-      on
-        contact.facility_id = facility.id
-        order by ghgr_import_id
+    $$
+    select distinct(facility.ghgr_import_id) from ggircs.contact
+    join ggircs.facility
+    on
+      contact.facility_id = facility.id
+      order by ghgr_import_id
     $$,
 
     'select ghgr_import_id from ggircs.facility order by ghgr_import_id',
@@ -1055,11 +1063,12 @@ select results_eq(
 
 -- Identifier -> Facility
 select results_eq(
-    $$select distinct(facility.ghgr_import_id) from ggircs.identifier
-      join ggircs.facility
-      on
-        identifier.facility_id = facility.id
-        order by ghgr_import_id
+    $$
+    select distinct(facility.ghgr_import_id) from ggircs.identifier
+    join ggircs.facility
+    on
+      identifier.facility_id = facility.id
+      order by ghgr_import_id
     $$,
 
     'select ghgr_import_id from ggircs.facility order by ghgr_import_id',
@@ -1069,11 +1078,12 @@ select results_eq(
 
 -- NAICS -> Facility
 select results_eq(
-    $$select distinct(facility.ghgr_import_id) from ggircs.naics
-      join ggircs.facility
-      on
-        naics.facility_id = facility.id
-        order by ghgr_import_id
+    $$
+    select distinct(facility.ghgr_import_id) from ggircs.naics
+    join ggircs.facility
+    on
+      naics.facility_id = facility.id
+      order by ghgr_import_id
     $$,
 
     'select ghgr_import_id from ggircs.facility order by ghgr_import_id',
@@ -1083,11 +1093,12 @@ select results_eq(
 
 -- Permit -> Facility
 select results_eq(
-    $$select facility.ghgr_import_id from ggircs.permit
-      join ggircs.facility
-      on
-        permit.facility_id = facility.id
-        order by ghgr_import_id
+    $$
+    select facility.ghgr_import_id from ggircs.permit
+    join ggircs.facility
+    on
+      permit.facility_id = facility.id
+      order by ghgr_import_id
     $$,
 
     'select ghgr_import_id from ggircs.facility order by ghgr_import_id',
@@ -1126,10 +1137,10 @@ select results_eq(
 
 -- Measured Emission Factor -> Fuel
 select results_eq(
-    $$select distinct(fuel.ghgr_import_id) from ggircs.measured_emission_factor
-      join ggircs.fuel
-      on
-        measured_emission_factor.fuel_id = fuel.id
+    $$
+    select distinct(fuel.ghgr_import_id) from ggircs.measured_emission_factor
+    join ggircs.fuel
+    on measured_emission_factor.fuel_id = fuel.id
     $$,
 
     'select distinct(ghgr_import_id) from ggircs.fuel',
@@ -1139,7 +1150,8 @@ select results_eq(
 
 /** Test data transferred from ggircs_swrs to ggircs properly **/
 -- Data in ggircs_swrs.report === data in ggircs_report
-select results_eq($$select
+select results_eq($$
+                  select
                       ghgr_import_id,
                       source_xml::text,
                       imported_at,
@@ -1161,7 +1173,8 @@ select results_eq($$select
                   order by ghgr_import_id
                   $$,
 
-                 $$select
+                 $$
+                 select
                       ghgr_import_id,
                       source_xml::text,
                       imported_at,
@@ -1186,7 +1199,8 @@ select results_eq($$select
     'data in ggircs_swrs.report === ggircs.report');
 
 -- Data in ggircs_swrs.organisation === data in ggircs.organisation
-select results_eq($$select
+select results_eq($$
+                  select
                       ghgr_import_id,
                       swrs_organisation_id,
                       business_legal_name,
@@ -1199,7 +1213,8 @@ select results_eq($$select
                   order by ghgr_import_id
                   $$,
 
-                 $$select
+                 $$
+                 select
                       ghgr_import_id,
                       swrs_organisation_id,
                       business_legal_name,
@@ -1215,7 +1230,8 @@ select results_eq($$select
     'data in ggircs_swrs.organisation === ggircs.organisation');
 
 -- Data in ggircs_swrs.activity === data in ggircs.activity
-select results_eq($$select
+select results_eq($$
+                  select
                       ghgr_import_id,
                       process_idx,
                       sub_process_idx,
@@ -1227,7 +1243,8 @@ select results_eq($$select
                   order by ghgr_import_id, process_idx, sub_process_idx, activity_name asc
                   $$,
 
-                 $$select
+                 $$
+                 select
                       ghgr_import_id,
                       process_idx,
                       sub_process_idx,
@@ -1243,7 +1260,8 @@ select results_eq($$select
 
 -- Data in ggircs_swrs.unit === data in ggircs.unit
 select results_eq(
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   activity_name,
                   process_idx,
@@ -1275,7 +1293,8 @@ select results_eq(
                  asc
               $$,
 
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   activity_name,
                   process_idx,
@@ -1311,7 +1330,8 @@ select results_eq(
 
 -- Data in ggircs_swrs.identifier === data in ggircs.identifier
 select results_eq(
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   swrs_facility_id,
                   path_context,
@@ -1327,7 +1347,8 @@ select results_eq(
                  asc
               $$,
 
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   swrs_facility_id,
                   path_context,
@@ -1347,7 +1368,8 @@ select results_eq(
 
 -- Data in ggircs_swrs.naics === data in ggircs.naics
 select results_eq(
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   swrs_facility_id,
                   path_context,
@@ -1364,7 +1386,8 @@ select results_eq(
                  asc
               $$,
 
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   swrs_facility_id,
                   path_context,
@@ -1385,7 +1408,8 @@ select results_eq(
 
 -- Data in ggircs_swrs.emission === data in ggircs.emission
 select results_eq(
-              $$select
+              $$
+              select
                 emission.ghgr_import_id,
                 activity_name,
                 sub_activity_name,
@@ -1422,7 +1446,8 @@ select results_eq(
                 emission_idx asc
               $$,
 
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   activity_name,
                   sub_activity_name,
@@ -1470,7 +1495,8 @@ select results_eq(
 
 -- Data in ggircs_swrs.fuel === data in ggircs.fuel
 select results_eq(
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   activity_name,
                   sub_activity_name,
@@ -1511,7 +1537,8 @@ select results_eq(
                  asc
               $$,
 
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   activity_name,
                   sub_activity_name,
@@ -1556,7 +1583,8 @@ select results_eq(
 
 -- Data in ggircs_swrs.permit === data in ggircs.permit
 select results_eq(
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   path_context,
                   permit_idx,
@@ -1570,7 +1598,8 @@ select results_eq(
                  asc
               $$,
 
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   path_context,
                   permit_idx,
@@ -1588,7 +1617,8 @@ select results_eq(
 
 -- Data in ggircs_swrs.parent_organisation === data in ggircs.parent_organisation
 select results_eq(
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   path_context,
                   parent_organisation_idx,
@@ -1606,7 +1636,8 @@ select results_eq(
                  asc
               $$,
 
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   path_context,
                   parent_organisation_idx,
@@ -1628,7 +1659,8 @@ select results_eq(
 
 -- Data in ggircs_swrs.contact === data in ggircs.contact
 select results_eq(
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   path_context,
                   contact_idx,
@@ -1650,7 +1682,8 @@ select results_eq(
                  asc
               $$,
 
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   path_context,
                   contact_idx,
@@ -1676,7 +1709,8 @@ select results_eq(
 
 -- Data in ggircs_swrs.address === data in ggircs.address
 select results_eq(
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   swrs_facility_id,
                   swrs_organisation_id,
@@ -1725,7 +1759,8 @@ select results_eq(
                  asc
               $$,
 
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   swrs_facility_id,
                   swrs_organisation_id,
@@ -1778,7 +1813,8 @@ select results_eq(
 
 -- Data in ggircs_swrs.descriptor === data in ggircs.descriptor
 select results_eq(
-              $$select
+              $$
+              select
                     ghgr_import_id,
                     process_idx,
                     sub_process_idx,
@@ -1806,7 +1842,8 @@ select results_eq(
                  asc
               $$,
 
-              $$select
+              $$
+              select
                     ghgr_import_id,
                     process_idx,
                     sub_process_idx,
@@ -1839,7 +1876,8 @@ select results_eq(
 
 -- Data in ggircs_swrs.measured_emission_factor === data in ggircs.measured_emission_factor
 select results_eq(
-              $$select
+              $$
+              select
                 ghgr_import_id,
                 activity_name,
                 sub_activity_name,
@@ -1869,7 +1907,8 @@ select results_eq(
                 measured_emission_factor_idx
               $$,
 
-              $$select
+              $$
+              select
                   ghgr_import_id,
                   activity_name,
                   sub_activity_name,

--- a/test/unit/materialized_view_activity_test.sql
+++ b/test/unit/materialized_view_activity_test.sql
@@ -78,13 +78,15 @@ refresh materialized view ggircs_swrs.activity with data;
 
 --  Test ghgr_import_id fk relation
 select results_eq(
-   'select ghgr_import.id from ggircs_swrs.activity ' ||
-   'join ggircs_swrs.ghgr_import ' ||
-   'on ' ||
-   'activity.ghgr_import_id =  ghgr_import.id ',
+   $$select ghgr_import.id from ggircs_swrs.activity
+   join ggircs_swrs.ghgr_import
+   on
+   activity.ghgr_import_id =  ghgr_import.id$$,
+
    'select id from ggircs_swrs.ghgr_import',
+
    'Foreign key ghgr_import_id ggircs_swrs_activity reference ggircs_swrs.ghgr_import'
-);
+   );
 
 -- test the columns for matview facility have been properly parsed from xml
 select results_eq(

--- a/test/unit/materialized_view_activity_test.sql
+++ b/test/unit/materialized_view_activity_test.sql
@@ -78,10 +78,12 @@ refresh materialized view ggircs_swrs.activity with data;
 
 --  Test ghgr_import_id fk relation
 select results_eq(
-   $$select ghgr_import.id from ggircs_swrs.activity
+   $$
+   select ghgr_import.id from ggircs_swrs.activity
    join ggircs_swrs.ghgr_import
    on
-   activity.ghgr_import_id =  ghgr_import.id$$,
+   activity.ghgr_import_id =  ghgr_import.id
+   $$,
 
    'select id from ggircs_swrs.ghgr_import',
 

--- a/test/unit/materialized_view_address_test.sql
+++ b/test/unit/materialized_view_address_test.sql
@@ -413,10 +413,11 @@ refresh materialized view ggircs_swrs.address with data;
 
 -- Test the fk relation from address to: facility
 select results_eq(
-    'select facility.ghgr_import_id from ggircs_swrs.address ' ||
-    'join ggircs_swrs.facility ' ||
-    'on ' ||
-    $$address.ghgr_import_id =  facility.ghgr_import_id and address.type ='Facility' $$,
+    $$
+    select facility.ghgr_import_id from ggircs_swrs.address
+    join ggircs_swrs.facility
+    on
+    address.ghgr_import_id =  facility.ghgr_import_id and address.type ='Facility' $$,
 
     'select ghgr_import_id from ggircs_swrs.facility',
 
@@ -425,10 +426,10 @@ select results_eq(
 
 -- Test the fk relation from address to organisation
 select results_eq(
-    'select organisation.ghgr_import_id from ggircs_swrs.address ' ||
-    'join ggircs_swrs.organisation ' ||
-    'on ' ||
-    $$address.ghgr_import_id =  organisation.ghgr_import_id and address.type='Organisation'$$,
+    $$select organisation.ghgr_import_id from ggircs_swrs.address
+    join ggircs_swrs.organisation
+    on
+    address.ghgr_import_id =  organisation.ghgr_import_id and address.type='Organisation'$$,
 
     'select ghgr_import_id from ggircs_swrs.organisation',
 
@@ -437,13 +438,13 @@ select results_eq(
 
 -- Test the fk relation from address to contact
 select results_eq(
-    'select contact.ghgr_import_id from ggircs_swrs.address ' ||
-    'join ggircs_swrs.contact ' ||
-    'on (' ||
-    'address.ghgr_import_id = contact.ghgr_import_id ' ||
-    'and address.contact_idx = contact.contact_idx) ' ||
-    $$and address.type='Contact' $$ ||
-    $$and address.contact_idx= 0$$,
+    $$select contact.ghgr_import_id from ggircs_swrs.address
+    join ggircs_swrs.contact
+    on (
+    address.ghgr_import_id = contact.ghgr_import_id
+    and address.contact_idx = contact.contact_idx)
+    and address.type='Contact'
+    and address.contact_idx= 0$$,
 
     'select ghgr_import_id from ggircs_swrs.contact where contact.contact_idx= 0',
 
@@ -452,13 +453,13 @@ select results_eq(
 
 -- Test the fk relation from address to parent_organisation
 select results_eq(
-    'select parent_organisation.ghgr_import_id from ggircs_swrs.address ' ||
-    'join ggircs_swrs.parent_organisation ' ||
-    'on (' ||
-    'address.ghgr_import_id = parent_organisation.ghgr_import_id ' ||
-    'and address.parent_organisation_idx = parent_organisation.parent_organisation_idx) ' ||
-    $$and address.type='ParentOrganisation' $$ ||
-    $$and address.parent_organisation_idx= 0$$,
+    $$select parent_organisation.ghgr_import_id from ggircs_swrs.address
+    join ggircs_swrs.parent_organisation
+    on (
+    address.ghgr_import_id = parent_organisation.ghgr_import_id
+    and address.parent_organisation_idx = parent_organisation.parent_organisation_idx)
+    and address.type='ParentOrganisation'
+    and address.parent_organisation_idx = 0 $$,
 
     'select ghgr_import_id from ggircs_swrs.parent_organisation where parent_organisation.parent_organisation_idx= 0',
 

--- a/test/unit/materialized_view_address_test.sql
+++ b/test/unit/materialized_view_address_test.sql
@@ -417,7 +417,8 @@ select results_eq(
     select facility.ghgr_import_id from ggircs_swrs.address
     join ggircs_swrs.facility
     on
-    address.ghgr_import_id =  facility.ghgr_import_id and address.type ='Facility' $$,
+    address.ghgr_import_id =  facility.ghgr_import_id and address.type ='Facility'
+    $$,
 
     'select ghgr_import_id from ggircs_swrs.facility',
 
@@ -426,10 +427,12 @@ select results_eq(
 
 -- Test the fk relation from address to organisation
 select results_eq(
-    $$select organisation.ghgr_import_id from ggircs_swrs.address
+    $$
+    select organisation.ghgr_import_id from ggircs_swrs.address
     join ggircs_swrs.organisation
     on
-    address.ghgr_import_id =  organisation.ghgr_import_id and address.type='Organisation'$$,
+    address.ghgr_import_id =  organisation.ghgr_import_id and address.type='Organisation'
+    $$,
 
     'select ghgr_import_id from ggircs_swrs.organisation',
 
@@ -438,13 +441,15 @@ select results_eq(
 
 -- Test the fk relation from address to contact
 select results_eq(
-    $$select contact.ghgr_import_id from ggircs_swrs.address
+    $$
+    select contact.ghgr_import_id from ggircs_swrs.address
     join ggircs_swrs.contact
     on (
     address.ghgr_import_id = contact.ghgr_import_id
     and address.contact_idx = contact.contact_idx)
     and address.type='Contact'
-    and address.contact_idx= 0$$,
+    and address.contact_idx = 0
+    $$,
 
     'select ghgr_import_id from ggircs_swrs.contact where contact.contact_idx= 0',
 
@@ -453,13 +458,15 @@ select results_eq(
 
 -- Test the fk relation from address to parent_organisation
 select results_eq(
-    $$select parent_organisation.ghgr_import_id from ggircs_swrs.address
+    $$
+    select parent_organisation.ghgr_import_id from ggircs_swrs.address
     join ggircs_swrs.parent_organisation
     on (
     address.ghgr_import_id = parent_organisation.ghgr_import_id
     and address.parent_organisation_idx = parent_organisation.parent_organisation_idx)
     and address.type='ParentOrganisation'
-    and address.parent_organisation_idx = 0 $$,
+    and address.parent_organisation_idx = 0
+    $$,
 
     'select ghgr_import_id from ggircs_swrs.parent_organisation where parent_organisation.parent_organisation_idx= 0',
 
@@ -469,175 +476,175 @@ select results_eq(
 
 -- test the columnns for ggircs_swrs.address have been properly parsed from xml when context is 'Facility'
 select results_eq(
-  $$select ghgr_import_id from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select ghgr_import_id from ggircs_swrs.address where address.type='Facility' $$,
   'select id from ggircs_swrs.ghgr_import',
   'ggircs_swrs.address parsed column ghgr_import_id'
 );
 
 select results_eq(
-  $$select type from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select type from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['Facility'::varchar],
   'ggircs_swrs.address parsed column type'
 );
 select results_eq(
-  $$select swrs_facility_id from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select swrs_facility_id from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY[666::integer],
   'ggircs_swrs.address parsed column swrs_facility_id'
 );
 -- test that the swrs_organisation_id is null when getting address from the context of facility
 select results_eq(
-  $$select swrs_organisation_id from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select swrs_organisation_id from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY[null::integer],
   'ggircs_swrs.address parsed column swrs_organisation_id'
 );
 
 -- Physical Address columns
 select results_eq(
-  $$select physical_address_unit_number from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_unit_number from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY[1::varchar],
   'ggircs_swrs.address parsed column physical_address_unit_number'
 );
 select results_eq(
-  $$select physical_address_street_number from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_street_number from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY[1234::varchar],
   'ggircs_swrs.address parsed column physical_address_street_number'
 );
 select results_eq(
-  $$select physical_address_street_number_suffix from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_street_number_suffix from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY[null::varchar],
   'ggircs_swrs.address parsed column physical_address_street_number_suffix'
 );
 select results_eq(
-  $$select physical_address_street_name from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_street_name from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['00th'::varchar],
   'ggircs_swrs.address parsed column physical_address_municipality'
 );
 select results_eq(
-  $$select physical_address_street_type from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_street_type from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['Avenue'::varchar],
   'ggircs_swrs.address parsed column physical_address_street_type'
 );
 select results_eq(
-  $$select physical_address_street_direction from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_street_direction from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['NW'::varchar],
   'ggircs_swrs.address parsed column physical_address_street_direction'
 );
 select results_eq(
-  $$select physical_address_municipality from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_municipality from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['Fort Nelson'::varchar],
   'ggircs_swrs.address parsed column physical_address_municipality'
 );
 select results_eq(
-  $$select physical_address_prov_terr_state from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_prov_terr_state from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['British Columbia'::varchar],
   'ggircs_swrs.address parsed column physical_address_prov_terr_state'
 );
 select results_eq(
-  $$select physical_address_postal_code_zip_code from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_postal_code_zip_code from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['H0H 0H0'::varchar],
   'ggircs_swrs.address parsed column physical_address_postal_code_zip_code'
 );
 select results_eq(
-  $$select physical_address_country from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_country from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['Canada'::varchar],
   'ggircs_swrs.address parsed column physical_address_country'
 );
 select results_eq(
-  $$select physical_address_national_topographical_description from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_national_topographical_description from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['A-123-B/456-C-00'::varchar],
   'ggircs_swrs.address parsed column physical_address_national_topographical_description'
 );
 select results_eq(
-  $$select physical_address_additional_information from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_additional_information from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['INFO'::varchar],
   'ggircs_swrs.address parsed column physical_address_additional_information'
 );
 select results_eq(
-  $$select physical_address_land_survey_description from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select physical_address_land_survey_description from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['OOH shiny!'::varchar],
   'ggircs_swrs.address parsed column physical_address_land_survey_description'
 );
 
 -- Mailing Address Columns
 select results_eq(
-  $$select mailing_address_delivery_mode from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_delivery_mode from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['Post Office Box'::varchar],
   'ggircs_swrs.address parsed column mailing_address_delivery_mode'
 );
 select results_eq(
-  $$select mailing_address_po_box_number from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_po_box_number from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['0000'::varchar],
   'ggircs_swrs.address parsed column mailing_address_po_box_number'
 );
 select results_eq(
-  $$select mailing_address_unit_number from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_unit_number from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['1'::varchar],
   'ggircs_swrs.address parsed column mailing_address_unit_number'
 );
 select results_eq(
-  $$select mailing_address_rural_route_number from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_rural_route_number from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['321'::varchar],
   'ggircs_swrs.address parsed column mailing_address_rural_route_number'
 );
 select results_eq(
-  $$select mailing_address_street_number from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_street_number from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY[1234::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_number'
 );
 select results_eq(
-  $$select mailing_address_street_number_suffix from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_street_number_suffix from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY[null::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_number_suffix'
 );
 select results_eq(
-  $$select mailing_address_street_name from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_street_name from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['00th'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_name'
 );
 select results_eq(
-  $$select mailing_address_street_type from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_street_type from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['Avenue'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_type'
 );
 select results_eq(
-  $$select mailing_address_street_direction from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_street_direction from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['West'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_direction'
 );
 select results_eq(
-  $$select mailing_address_municipality from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_municipality from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['Fort Nelson'::varchar],
   'ggircs_swrs.address parsed column mailing_address_municipality'
 );
 select results_eq(
-  $$select mailing_address_prov_terr_state from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_prov_terr_state from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['British Columbia'::varchar],
   'ggircs_swrs.address parsed column mailing_address_prov_terr_state'
 );
 select results_eq(
-  $$select mailing_address_postal_code_zip_code from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_postal_code_zip_code from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['H0H 0H0'::varchar],
   'ggircs_swrs.address parsed column mailing_address_postal_code_zip_code'
 );
 select results_eq(
-  $$select mailing_address_country from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_country from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['Canada'::varchar],
   'ggircs_swrs.address parsed column mailing_address_country'
 );
 select results_eq(
-  $$select mailing_address_additional_information from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select mailing_address_additional_information from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY['The site is located at A-123-B-456-C-789'::varchar],
   'ggircs_swrs.address parsed column mailing_address_additional_information'
 );
 
 -- Geographic Address columns
 select results_eq(
-  $$select geographic_address_latitude from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select geographic_address_latitude from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY[23.45125::numeric],
   'ggircs_swrs.address parsed column geographic_address_latitude'
 );
 select results_eq(
-  $$select geographic_address_longitude from ggircs_swrs.address where address.type='Facility'$$,
+  $$ select geographic_address_longitude from ggircs_swrs.address where address.type='Facility' $$,
   ARRAY[-90.59062::numeric],
   'ggircs_swrs.address parsed column geographic_address_longitude'
 );
@@ -646,175 +653,175 @@ select results_eq(
 
 -- test the columnns for ggircs_swrs.address have been properly parsed from xml when context is 'Organisation'
 select results_eq(
-  $$select ghgr_import_id from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select ghgr_import_id from ggircs_swrs.address where address.type='Organisation' $$,
   'select id from ggircs_swrs.ghgr_import',
   'ggircs_swrs.address parsed column ghgr_import_id'
 );
 select results_eq(
-  $$select type from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select type from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['Organisation'::varchar],
   'ggircs_swrs.address parsed column type'
 );
 -- test that the swrs_facility_id is null when getting address from the context of organisation
 select results_eq(
-  $$select swrs_facility_id from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select swrs_facility_id from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY[null::integer],
   'ggircs_swrs.address parsed column swrs_organisation_id'
 );
 
 select results_eq(
-  $$select swrs_organisation_id from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select swrs_organisation_id from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY[123::integer],
   'ggircs_swrs.address parsed column swrs_organisation_id'
 );
 
 -- Physical Address columns
 select results_eq(
-  $$select physical_address_unit_number from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_unit_number from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY[4321::varchar],
   'ggircs_swrs.address parsed column physical_address_unit_number'
 );
 select results_eq(
-  $$select physical_address_street_number from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_street_number from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY[100::varchar],
   'ggircs_swrs.address parsed column physical_address_street_number'
 );
 select results_eq(
-  $$select physical_address_street_number_suffix from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_street_number_suffix from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY[null::varchar],
   'ggircs_swrs.address parsed column physical_address_street_number_suffix'
 );
 select results_eq(
-  $$select physical_address_street_name from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_street_name from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['111th Street West'::varchar],
   'ggircs_swrs.address parsed column physical_address_street_name'
 );
 select results_eq(
-  $$select physical_address_street_type from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_street_type from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['Street'::varchar],
   'ggircs_swrs.address parsed column physical_address_street_type'
 );
 select results_eq(
-  $$select physical_address_street_direction from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_street_direction from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['West'::varchar],
   'ggircs_swrs.address parsed column physical_address_street_direction'
 );
 select results_eq(
-  $$select physical_address_municipality from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_municipality from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['Funkytown'::varchar],
   'ggircs_swrs.address parsed column physical_address_municipality'
 );
 select results_eq(
-  $$select physical_address_prov_terr_state from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_prov_terr_state from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['Funky'::varchar],
   'ggircs_swrs.address parsed column physical_address_prov_terr_state'
 );
 select results_eq(
-  $$select physical_address_postal_code_zip_code from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_postal_code_zip_code from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['H0H0H0'::varchar],
   'ggircs_swrs.address parsed column physical_address_postal_code_zip_code'
 );
 select results_eq(
-  $$select physical_address_country from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_country from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['Canada'::varchar],
   'ggircs_swrs.address parsed column physical_address_country'
 );
 select results_eq(
-  $$select physical_address_national_topographical_description from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_national_topographical_description from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['A-123-B/456-C-00'::varchar],
   'ggircs_swrs.address parsed column physical_address_national_topographical_description'
 );
 select results_eq(
-  $$select physical_address_additional_information from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_additional_information from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['INFO'::varchar],
   'ggircs_swrs.address parsed column physical_address_additional_information'
 );
 select results_eq(
-  $$select physical_address_land_survey_description from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select physical_address_land_survey_description from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['OOH shiny!'::varchar],
   'ggircs_swrs.address parsed column physical_address_land_survey_description'
 );
 
 -- Mailing Address Columns
 select results_eq(
-  $$select mailing_address_delivery_mode from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_delivery_mode from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['General Delivery'::varchar],
   'ggircs_swrs.address parsed column mailing_address_delivery_mode'
 );
 select results_eq(
-  $$select mailing_address_po_box_number from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_po_box_number from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['0000'::varchar],
   'ggircs_swrs.address parsed column mailing_address_po_box_number'
 );
 select results_eq(
-  $$select mailing_address_unit_number from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_unit_number from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['00'::varchar],
   'ggircs_swrs.address parsed column mailing_address_unit_number'
 );
 select results_eq(
-  $$select mailing_address_rural_route_number from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_rural_route_number from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['321'::varchar],
   'ggircs_swrs.address parsed column mailing_address_rural_route_number'
 );
 select results_eq(
-  $$select mailing_address_street_number from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_street_number from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY[100::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_number'
 );
 select results_eq(
-  $$select mailing_address_street_number_suffix from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_street_number_suffix from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['B'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_number_suffix'
 );
 select results_eq(
-  $$select mailing_address_street_name from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_street_name from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['111th Street West'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_name'
 );
 select results_eq(
-  $$select mailing_address_street_type from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_street_type from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['Street'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_type'
 );
 select results_eq(
-  $$select mailing_address_street_direction from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_street_direction from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['West'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_direction'
 );
 select results_eq(
-  $$select mailing_address_municipality from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_municipality from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['Funkytown'::varchar],
   'ggircs_swrs.address parsed column mailing_address_municipality'
 );
 select results_eq(
-  $$select mailing_address_prov_terr_state from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_prov_terr_state from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['Funky'::varchar],
   'ggircs_swrs.address parsed column mailing_address_prov_terr_state'
 );
 select results_eq(
-  $$select mailing_address_postal_code_zip_code from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_postal_code_zip_code from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['H0H0H0'::varchar],
   'ggircs_swrs.address parsed column mailing_address_postal_code_zip_code'
 );
 select results_eq(
-  $$select mailing_address_country from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_country from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY['Canada'::varchar],
   'ggircs_swrs.address parsed column mailing_address_country'
 );
 select results_eq(
-  $$select mailing_address_additional_information from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select mailing_address_additional_information from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY[null::varchar],
   'ggircs_swrs.address parsed column mailing_address_additional_information'
 );
 
 -- Geographic Address columns
 select results_eq(
-  $$select geographic_address_latitude from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select geographic_address_latitude from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY[23.45125::numeric],
   'ggircs_swrs.address parsed column geographic_address_latitude'
 );
 select results_eq(
-  $$select geographic_address_longitude from ggircs_swrs.address where address.type='Organisation'$$,
+  $$ select geographic_address_longitude from ggircs_swrs.address where address.type='Organisation' $$,
   ARRAY[-90.59062::numeric],
   'ggircs_swrs.address parsed column geographic_address_longitude'
 );
@@ -823,164 +830,164 @@ select results_eq(
 
 -- test the columnns for ggircs_swrs.address have been properly parsed from xml when context is 'Contact'
 select results_eq(
-  $$select ghgr_import_id from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select ghgr_import_id from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   'select id from ggircs_swrs.ghgr_import',
   'ggircs_swrs.address parsed column ghgr_import_id'
 );
 select results_eq(
-  $$select type from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select type from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['Contact'::varchar],
   'ggircs_swrs.address parsed column type'
 );
 
 select results_eq(
-  $$select swrs_facility_id from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select swrs_facility_id from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY[666::integer],
   'ggircs_swrs.address parsed column swrs_contact_id'
 );
 
 -- test that the swrs_organisation_id is null when getting address from the context of contact
 select results_eq(
-  $$select swrs_organisation_id from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select swrs_organisation_id from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY[null::integer],
   'ggircs_swrs.address parsed column swrs_organisation_id'
 );
 
 -- Physical Address columns
 select results_eq(
-  $$select physical_address_unit_number from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_unit_number from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY[1::varchar],
   'ggircs_swrs.address parsed column physical_address_unit_number'
 );
 select results_eq(
-  $$select physical_address_street_number from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_street_number from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY[1234::varchar],
   'ggircs_swrs.address parsed column physical_address_street_number'
 );
 select results_eq(
-  $$select physical_address_street_number_suffix from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_street_number_suffix from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY[null::varchar],
   'ggircs_swrs.address parsed column physical_address_street_number_suffix'
 );
 select results_eq(
-  $$select physical_address_street_name from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_street_name from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['00th'::varchar],
   'ggircs_swrs.address parsed column physical_address_municipality'
 );
 select results_eq(
-  $$select physical_address_street_type from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_street_type from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['Avenue'::varchar],
   'ggircs_swrs.address parsed column physical_address_street_type'
 );
 select results_eq(
-  $$select physical_address_street_direction from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_street_direction from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['NW'::varchar],
   'ggircs_swrs.address parsed column physical_address_street_direction'
 );
 select results_eq(
-  $$select physical_address_municipality from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_municipality from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['Fort Nelson'::varchar],
   'ggircs_swrs.address parsed column physical_address_municipality'
 );
 select results_eq(
-  $$select physical_address_prov_terr_state from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_prov_terr_state from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['British Columbia'::varchar],
   'ggircs_swrs.address parsed column physical_address_prov_terr_state'
 );
 select results_eq(
-  $$select physical_address_postal_code_zip_code from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_postal_code_zip_code from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['H0H 0H0'::varchar],
   'ggircs_swrs.address parsed column physical_address_postal_code_zip_code'
 );
 select results_eq(
-  $$select physical_address_country from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_country from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['Canada'::varchar],
   'ggircs_swrs.address parsed column physical_address_country'
 );
 select results_eq(
-  $$select physical_address_national_topographical_description from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_national_topographical_description from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['A-123-B/456-C-00'::varchar],
   'ggircs_swrs.address parsed column physical_address_national_topographical_description'
 );
 select results_eq(
-  $$select physical_address_additional_information from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_additional_information from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['INFO'::varchar],
   'ggircs_swrs.address parsed column physical_address_additional_information'
 );
 select results_eq(
-  $$select physical_address_land_survey_description from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select physical_address_land_survey_description from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['OOH shiny!'::varchar],
   'ggircs_swrs.address parsed column physical_address_land_survey_description'
 );
 
 -- Mailing Address Columns
 select results_eq(
-  $$select mailing_address_delivery_mode from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_delivery_mode from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['Post Office Box'::varchar],
   'ggircs_swrs.address parsed column mailing_address_delivery_mode'
 );
 select results_eq(
-  $$select mailing_address_po_box_number from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_po_box_number from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['0000'::varchar],
   'ggircs_swrs.address parsed column mailing_address_po_box_number'
 );
 select results_eq(
-  $$select mailing_address_unit_number from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_unit_number from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['1'::varchar],
   'ggircs_swrs.address parsed column mailing_address_unit_number'
 );
 select results_eq(
-  $$select mailing_address_rural_route_number from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_rural_route_number from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['321'::varchar],
   'ggircs_swrs.address parsed column mailing_address_rural_route_number'
 );
 select results_eq(
-  $$select mailing_address_street_number from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_street_number from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY[1234::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_number'
 );
 select results_eq(
-  $$select mailing_address_street_number_suffix from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_street_number_suffix from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY[null::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_number_suffix'
 );
 select results_eq(
-  $$select mailing_address_street_name from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_street_name from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['00th'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_name'
 );
 select results_eq(
-  $$select mailing_address_street_type from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_street_type from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['Avenue'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_type'
 );
 select results_eq(
-  $$select mailing_address_street_direction from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_street_direction from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['West'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_direction'
 );
 select results_eq(
-  $$select mailing_address_municipality from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_municipality from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['Fort Nelson'::varchar],
   'ggircs_swrs.address parsed column mailing_address_municipality'
 );
 select results_eq(
-  $$select mailing_address_prov_terr_state from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_prov_terr_state from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['British Columbia'::varchar],
   'ggircs_swrs.address parsed column mailing_address_prov_terr_state'
 );
 select results_eq(
-  $$select mailing_address_postal_code_zip_code from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_postal_code_zip_code from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['H0H 0H0'::varchar],
   'ggircs_swrs.address parsed column mailing_address_postal_code_zip_code'
 );
 select results_eq(
-  $$select mailing_address_country from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_country from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['Canada'::varchar],
   'ggircs_swrs.address parsed column mailing_address_country'
 );
 select results_eq(
-  $$select mailing_address_additional_information from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0$$,
+  $$ select mailing_address_additional_information from ggircs_swrs.address where address.type='Contact' and address.contact_idx=0 $$,
   ARRAY['The site is located at A-123-B-456-C-789'::varchar],
   'ggircs_swrs.address parsed column mailing_address_additional_information'
 );
@@ -989,162 +996,162 @@ select results_eq(
 
 -- test the columnns for ggircs_swrs.address have been properly parsed from xml when context is 'ParentOrganisation'
 select results_eq(
-  $$select ghgr_import_id from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select ghgr_import_id from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   'select id from ggircs_swrs.ghgr_import',
   'ggircs_swrs.address parsed column ghgr_import_id'
 );
 select results_eq(
-  $$select type from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select type from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['ParentOrganisation'::varchar],
   'ggircs_swrs.address parsed column type'
 );
 select results_eq(
-  $$select swrs_facility_id from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select swrs_facility_id from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY[null::integer],
   'ggircs_swrs.address parsed column swrs_parent_organisation_id'
 );
 -- test that the swrs_organisation_id is null when getting address from the context of parent_organisation
 select results_eq(
-  $$select swrs_organisation_id from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select swrs_organisation_id from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY[123::integer],
   'ggircs_swrs.address parsed column swrs_organisation_id'
 );
 
 -- Physical Address columns
 select results_eq(
-  $$select physical_address_unit_number from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_unit_number from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY[1::varchar],
   'ggircs_swrs.address parsed column physical_address_unit_number'
 );
 select results_eq(
-  $$select physical_address_street_number from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_street_number from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY[1234::varchar],
   'ggircs_swrs.address parsed column physical_address_street_number'
 );
 select results_eq(
-  $$select physical_address_street_number_suffix from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_street_number_suffix from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY[null::varchar],
   'ggircs_swrs.address parsed column physical_address_street_number_suffix'
 );
 select results_eq(
-  $$select physical_address_street_name from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_street_name from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['00th'::varchar],
   'ggircs_swrs.address parsed column physical_address_municipality'
 );
 select results_eq(
-  $$select physical_address_street_type from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_street_type from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['Avenue'::varchar],
   'ggircs_swrs.address parsed column physical_address_street_type'
 );
 select results_eq(
-  $$select physical_address_street_direction from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_street_direction from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['NW'::varchar],
   'ggircs_swrs.address parsed column physical_address_street_direction'
 );
 select results_eq(
-  $$select physical_address_municipality from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_municipality from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['Fort Nelson'::varchar],
   'ggircs_swrs.address parsed column physical_address_municipality'
 );
 select results_eq(
-  $$select physical_address_prov_terr_state from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_prov_terr_state from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['British Columbia'::varchar],
   'ggircs_swrs.address parsed column physical_address_prov_terr_state'
 );
 select results_eq(
-  $$select physical_address_postal_code_zip_code from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_postal_code_zip_code from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['H0H 0H0'::varchar],
   'ggircs_swrs.address parsed column physical_address_postal_code_zip_code'
 );
 select results_eq(
-  $$select physical_address_country from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_country from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['Canada'::varchar],
   'ggircs_swrs.address parsed column physical_address_country'
 );
 select results_eq(
-  $$select physical_address_national_topographical_description from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_national_topographical_description from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['A-123-B/456-C-00'::varchar],
   'ggircs_swrs.address parsed column physical_address_national_topographical_description'
 );
 select results_eq(
-  $$select physical_address_additional_information from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_additional_information from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['INFO'::varchar],
   'ggircs_swrs.address parsed column physical_address_additional_information'
 );
 select results_eq(
-  $$select physical_address_land_survey_description from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select physical_address_land_survey_description from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['OOH shiny!'::varchar],
   'ggircs_swrs.address parsed column physical_address_land_survey_description'
 );
 
 -- Mailing Address Columns
 select results_eq(
-  $$select mailing_address_delivery_mode from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_delivery_mode from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['Post Office Box'::varchar],
   'ggircs_swrs.address parsed column mailing_address_delivery_mode'
 );
 select results_eq(
-  $$select mailing_address_po_box_number from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_po_box_number from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['0000'::varchar],
   'ggircs_swrs.address parsed column mailing_address_po_box_number'
 );
 select results_eq(
-  $$select mailing_address_unit_number from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_unit_number from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['1'::varchar],
   'ggircs_swrs.address parsed column mailing_address_unit_number'
 );
 select results_eq(
-  $$select mailing_address_rural_route_number from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_rural_route_number from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['321'::varchar],
   'ggircs_swrs.address parsed column mailing_address_rural_route_number'
 );
 select results_eq(
-  $$select mailing_address_street_number from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_street_number from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY[1234::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_number'
 );
 select results_eq(
-  $$select mailing_address_street_number_suffix from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_street_number_suffix from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY[null::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_number_suffix'
 );
 select results_eq(
-  $$select mailing_address_street_name from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_street_name from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['00th'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_name'
 );
 select results_eq(
-  $$select mailing_address_street_type from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_street_type from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['Avenue'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_type'
 );
 select results_eq(
-  $$select mailing_address_street_direction from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_street_direction from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['West'::varchar],
   'ggircs_swrs.address parsed column mailing_address_street_direction'
 );
 select results_eq(
-  $$select mailing_address_municipality from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_municipality from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['Fort Nelson'::varchar],
   'ggircs_swrs.address parsed column mailing_address_municipality'
 );
 select results_eq(
-  $$select mailing_address_prov_terr_state from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_prov_terr_state from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['British Columbia'::varchar],
   'ggircs_swrs.address parsed column mailing_address_prov_terr_state'
 );
 select results_eq(
-  $$select mailing_address_postal_code_zip_code from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_postal_code_zip_code from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['H0H 0H0'::varchar],
   'ggircs_swrs.address parsed column mailing_address_postal_code_zip_code'
 );
 select results_eq(
-  $$select mailing_address_country from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_country from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['Canada'::varchar],
   'ggircs_swrs.address parsed column mailing_address_country'
 );
 select results_eq(
-  $$select mailing_address_additional_information from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0$$,
+  $$ select mailing_address_additional_information from ggircs_swrs.address where address.type='ParentOrganisation' and address.parent_organisation_idx=0 $$,
   ARRAY['The site is located at A-123-B-456-C-789'::varchar],
   'ggircs_swrs.address parsed column mailing_address_additional_information'
 );

--- a/test/unit/materialized_view_contact_test.sql
+++ b/test/unit/materialized_view_contact_test.sql
@@ -128,11 +128,11 @@ refresh materialized view ggircs_swrs.contact with data;
 
 --  Test ghgr_import_id fk relation
 select results_eq(
-   'select facility.ghgr_import_id from ggircs_swrs.contact ' ||
-   'join ggircs_swrs.facility ' ||
-   'on ' ||
-   'contact.ghgr_import_id =  facility.ghgr_import_id ' ||
-    'and contact.contact_idx=0',
+   $$select facility.ghgr_import_id from ggircs_swrs.contact
+   join ggircs_swrs.facility
+   on
+   contact.ghgr_import_id =  facility.ghgr_import_id
+   and contact.contact_idx=0$$,
 
    'select ghgr_import_id from ggircs_swrs.facility',
 

--- a/test/unit/materialized_view_contact_test.sql
+++ b/test/unit/materialized_view_contact_test.sql
@@ -128,11 +128,13 @@ refresh materialized view ggircs_swrs.contact with data;
 
 --  Test ghgr_import_id fk relation
 select results_eq(
-   $$select facility.ghgr_import_id from ggircs_swrs.contact
+   $$
+   select facility.ghgr_import_id from ggircs_swrs.contact
    join ggircs_swrs.facility
    on
    contact.ghgr_import_id =  facility.ghgr_import_id
-   and contact.contact_idx=0$$,
+   and contact.contact_idx=0
+   $$,
 
    'select ghgr_import_id from ggircs_swrs.facility',
 

--- a/test/unit/materialized_view_descriptor_test.sql
+++ b/test/unit/materialized_view_descriptor_test.sql
@@ -122,11 +122,13 @@ refresh materialized view ggircs_swrs.descriptor with data;
 
 --  Test ghgr_import_id fk relation
 select results_eq(
-    $$select ghgr_import.id from ggircs_swrs.descriptor
+    $$
+    select ghgr_import.id from ggircs_swrs.descriptor
     join ggircs_swrs.ghgr_import
     on
     descriptor.ghgr_import_id =  ghgr_import.id
-    and class='Amount'$$,
+    and class='Amount'
+    $$,
 
     'select id from ggircs_swrs.ghgr_import',
 
@@ -142,77 +144,77 @@ select results_eq(
 
 -- test that root level descriptors being extracted
 select results_eq(
-  $$select node_value from ggircs_swrs.descriptor where class='NumberOfTimesMissingDataProcedures' $$,
+  $$ select node_value from ggircs_swrs.descriptor where class='NumberOfTimesMissingDataProcedures' $$,
   Array['40'::varchar],
   'ggircs_swrs.descriptor.node_value is extracted where class is NumberOfTimesMissingDataProcedures'
 );
 
 -- test that medium level descriptors being extracted
 select results_eq(
-  $$select node_value from ggircs_swrs.descriptor where class='LimeTypeName' $$,
+  $$ select node_value from ggircs_swrs.descriptor where class='LimeTypeName' $$,
   Array['Quicklime'::varchar],
   'ggircs_swrs.descriptor.node_value is extracted where class is LimeTypeName'
 );
 
 -- test that medium level descriptors have the right parent
 select results_eq(
-  $$select parent from ggircs_swrs.descriptor where class='LimeTypeName' $$,
+  $$ select parent from ggircs_swrs.descriptor where class='LimeTypeName' $$,
   Array['LimeMonthlyDetails'::varchar],
   'ggircs_swrs.descriptor.parent is extracted where class is LimeTypeName'
 );
 
 -- test that mutiple activity_names are being created based on child of ReportData (e.g. ActivityPages, ProcessFlowDiagram etc.)
 select results_eq(
-  $$select activity_name from ggircs_swrs.descriptor where class='UploadedFileName' $$,
+  $$ select activity_name from ggircs_swrs.descriptor where class='UploadedFileName' $$,
   Array['ProcessFlowDiagram'::varchar],
   'ggircs_swrs.descriptor.activity_name is extracted where class is UploadedFileName'
 );
 
 -- test that values in the ProcessFlowDiagram activity_name is extracted
 select results_eq(
-  $$select node_value from ggircs_swrs.descriptor where class='UploadedFileName' $$,
+  $$ select node_value from ggircs_swrs.descriptor where class='UploadedFileName' $$,
   Array['all_our_base.pdf'::varchar],
   'ggircs_swrs.descriptor.node_value is extracted where class is UploadedFileName'
 );
 
 -- test that process_idx is being generated properly when multiple preciding siblings
 select results_eq(
-  $$select process_idx from ggircs_swrs.descriptor where class='UploadedFileName' $$,
+  $$ select process_idx from ggircs_swrs.descriptor where class='UploadedFileName' $$,
   Array[1::integer],
   'ggircs_swrs.descriptor.process_idx is extracted where class is UploadedFileName'
 );
 
 -- test that sub_process_idx is being generated properly when multiple preciding siblings
 select results_eq(
-  $$select sub_process_idx from ggircs_swrs.descriptor where class='UploadedFileName' $$,
+  $$ select sub_process_idx from ggircs_swrs.descriptor where class='UploadedFileName' $$,
   Array[1::integer],
   'ggircs_swrs.descriptor.sub_process_idx is extracted where class is UploadedFileName'
 );
 
 -- test that parent_idx is being generated properly when multiple preciding siblings
 select results_eq(
-  $$select parent_idx from ggircs_swrs.descriptor where class='LimeTypeName' $$,
+  $$ select parent_idx from ggircs_swrs.descriptor where class='LimeTypeName' $$,
   Array[0::integer],
   'ggircs_swrs.descriptor.process_idx is extracted where class is LimeTypeName'
 );
 
 -- test that grandparent_idx is being generated properly when multiple preciding siblings
 select results_eq(
-  $$select grandparent_idx from ggircs_swrs.descriptor where class='LimeTypeName' $$,
+  $$ select grandparent_idx from ggircs_swrs.descriptor where class='LimeTypeName' $$,
   Array[1::integer],
   'ggircs_swrs.descriptor.process_idx is extracted where class is LimeTypeName'
 );
 
 -- test that sub_process_idx is being generated properly when multiple preciding siblings
 select results_eq(
-  $$select sub_process_idx from ggircs_swrs.descriptor where class='UploadedFileName' $$,
+  $$ select sub_process_idx from ggircs_swrs.descriptor where class='UploadedFileName' $$,
   Array[1::integer],
   'ggircs_swrs.descriptor.sub_process_idx is extracted where class is UploadedFileName'
 );
 
 -- test that multi-attribute concatenation is working
 select results_eq(
-  $$select node_value from ggircs_swrs.descriptor where attr_value like '%Lime Produced Monthly%' $$,
+  $$ select node_value from ggircs_swrs.descriptor where attr_value like '%Lime Produced Monthly%' $$,
   Array['2918.22'::varchar],
   'ggircs_swrs.descriptor.sub_process_idx is extracted where class is Lime Produced Monthly'
 );

--- a/test/unit/materialized_view_descriptor_test.sql
+++ b/test/unit/materialized_view_descriptor_test.sql
@@ -122,11 +122,11 @@ refresh materialized view ggircs_swrs.descriptor with data;
 
 --  Test ghgr_import_id fk relation
 select results_eq(
-    'select ghgr_import.id from ggircs_swrs.descriptor ' ||
-    'join ggircs_swrs.ghgr_import ' ||
-    'on ' ||
-    'descriptor.ghgr_import_id =  ghgr_import.id ' ||
-    $$and class='Amount'$$,
+    $$select ghgr_import.id from ggircs_swrs.descriptor
+    join ggircs_swrs.ghgr_import
+    on
+    descriptor.ghgr_import_id =  ghgr_import.id
+    and class='Amount'$$,
 
     'select id from ggircs_swrs.ghgr_import',
 

--- a/test/unit/materialized_view_emission_test.sql
+++ b/test/unit/materialized_view_emission_test.sql
@@ -183,12 +183,12 @@ refresh materialized view ggircs_swrs.emission with data;
 
 --  Test ghgr_import_id fk relation
 select results_eq(
-    'select fuel.ghgr_import_id from ggircs_swrs.emission ' ||
-    'join ggircs_swrs.fuel ' ||
-    'on ' ||
-    'emission.ghgr_import_id =  fuel.ghgr_import_id ' ||
-    'and emission.fuel_idx = fuel.fuel_idx ' ||
-    'and emission.emission_idx=0',
+    $$select fuel.ghgr_import_id from ggircs_swrs.emission
+    join ggircs_swrs.fuel
+    on
+    emission.ghgr_import_id =  fuel.ghgr_import_id
+    and emission.fuel_idx = fuel.fuel_idx
+    and emission.emission_idx=0$$,
 
     'select ghgr_import_id from ggircs_swrs.fuel',
 

--- a/test/unit/materialized_view_emission_test.sql
+++ b/test/unit/materialized_view_emission_test.sql
@@ -7,7 +7,6 @@ begin;
 
 select plan(67);
 
-
 select has_materialized_view(
     'ggircs_swrs', 'emission',
     'ggircs_swrs.emission should be a materialized view'
@@ -183,12 +182,14 @@ refresh materialized view ggircs_swrs.emission with data;
 
 --  Test ghgr_import_id fk relation
 select results_eq(
-    $$select fuel.ghgr_import_id from ggircs_swrs.emission
+    $$
+    select fuel.ghgr_import_id from ggircs_swrs.emission
     join ggircs_swrs.fuel
     on
     emission.ghgr_import_id =  fuel.ghgr_import_id
     and emission.fuel_idx = fuel.fuel_idx
-    and emission.emission_idx=0$$,
+    and emission.emission_idx=0
+    $$,
 
     'select ghgr_import_id from ggircs_swrs.fuel',
 
@@ -197,35 +198,35 @@ select results_eq(
 
 -- test the columns for matview facility have been properly parsed from xml
 select results_eq(
-  $$select ghgr_import_id from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select ghgr_import_id from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
   'select id from ggircs_swrs.ghgr_import',
   'ggircs_swrs.emission.ghgr_import_id relates to ggircs_swrs.ghgr_import.id'
 );
 
 -- Extract process_idx
 select results_eq(
-  $$select process_idx from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select process_idx from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
    ARRAY[0::integer],
   'ggircs_swrs.emission.process_idx is extracted'
 );
 
 -- Extract sub_process_idx
 select results_eq(
-  $$select sub_process_idx from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select sub_process_idx from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
    ARRAY[0::integer],
   'ggircs_swrs.emission.sub_process_idx is extracted'
 );
 
 -- Extract unit_idx
 select results_eq(
-  $$select unit_idx from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select unit_idx from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
    ARRAY[0::integer],
   'ggircs_swrs.emission.unit_idx is extracted'
 );
 
 -- Extract fuel_idx
 select results_eq(
-  $$select fuel_idx from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select fuel_idx from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
    ARRAY[0::integer],
   'ggircs_swrs.emission.fuel_idx is extracted'
 );
@@ -233,7 +234,7 @@ select results_eq(
 
 -- Extract emission_idx
 select results_eq(
-  $$select emission_idx from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select emission_idx from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
    ARRAY[0::integer],
   'ggircs_swrs.emission.emission_idx is extracted'
 
@@ -241,49 +242,49 @@ select results_eq(
 
 -- Extract emission_type
 select results_eq(
-  $$select emission_type from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select emission_type from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
    ARRAY['Combustion: Field gas or Process Vent Gas'::varchar(1000)],
   'ggircs_swrs.emission.emission_type is extracted'
 );
 
 -- Extract gas_type
 select results_eq(
-  $$select gas_type from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select gas_type from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
    ARRAY['CO2nonbio'::varchar(1000)],
   'ggircs_swrs.emission.gas_type is extracted'
 );
 
 -- Extract methodology
 select results_eq(
-  $$select methodology from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select methodology from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
    ARRAY['Methodology 2 (measured HHV/Steam)'::varchar(1000)],
   'ggircs_swrs.emission.methodology is extracted'
 );
 
 -- Extract not_applicable
   select results_eq(
-  $$select not_applicable from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select not_applicable from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
    ARRAY['false'::bool],
   'ggircs_swrs.emission.not_applicable is extracted'
 );
 
 -- Extract quantity
   select results_eq(
-  $$select quantity from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select quantity from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
    ARRAY[28215::numeric(1000,0)],
   'ggircs_swrs.emission.quantity is extracted'
 );
 
 -- Extract calculated_quantity
   select results_eq(
-  $$select calculated_quantity from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select calculated_quantity from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
    ARRAY[28215::numeric(1000,0)],
   'ggircs_swrs.emission.calculated_quantity is extracted'
 );
 
 -- Extract emission_category
 select results_eq(
-  $$select emission_category::varchar from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0$$,
+  $$ select emission_category::varchar from ggircs_swrs.emission where fuel_idx=0 and emission_idx=0 $$,
    ARRAY['BC_ScheduleB_GeneralStationaryCombustionEmissions'::varchar(1000)],
   'ggircs_swrs.emission.emission_category is extracted'
 );

--- a/test/unit/materialized_view_facility_test.sql
+++ b/test/unit/materialized_view_facility_test.sql
@@ -105,11 +105,13 @@ refresh materialized view ggircs_swrs.facility with data;
 
 -- Test ghgr_import_id fk relation
 select results_eq(
-    $$ select ghgr_import.id from ggircs_swrs.facility
+    $$
+    select ghgr_import.id from ggircs_swrs.facility
     join ggircs_swrs.ghgr_import
     on
     facility.ghgr_import_id =  ghgr_import.id
-    order by ghgr_import.id desc limit 1$$,
+    order by ghgr_import.id desc limit 1
+    $$,
 
     'select id from ggircs_swrs.ghgr_import order by id desc limit 1',
 

--- a/test/unit/materialized_view_final_report_test.sql
+++ b/test/unit/materialized_view_final_report_test.sql
@@ -120,10 +120,12 @@ refresh materialized view ggircs_swrs.final_report with data;
 
 -- Test ghgr_import_id fk relation
 select results_eq(
-    $$select report.swrs_report_id from ggircs_swrs.final_report
+    $$
+    select report.swrs_report_id from ggircs_swrs.final_report
     join ggircs_swrs.report
     on
-    final_report.swrs_report_id = report.swrs_report_id $$,
+    final_report.swrs_report_id = report.swrs_report_id
+    $$,
 
     'select swrs_report_id from ggircs_swrs.report',
 
@@ -137,8 +139,8 @@ select results_eq(
 );
 
 select results_eq(
-  $$select ghgr_import_id from ggircs_swrs.final_report$$,
-  $$select ghgr_import_id from ggircs_swrs.report where status = 'Archived'$$,
+  'select ghgr_import_id from ggircs_swrs.final_report',
+  $$ select ghgr_import_id from ggircs_swrs.report where status = 'Archived' $$,
   'ggircs_swrs.final_report.ghgr_import_id should refer to the correct version'
 );
 
@@ -219,7 +221,7 @@ $$);
 
 -- Test that the ignore_list is properly ignoring reports by swrs_organisation_id
 select is_empty(
-    $$select * from ggircs_swrs.final_report where swrs_report_id = 12345 $$,
+    'select * from ggircs_swrs.final_report where swrs_report_id = 12345',
     'ggircs_swrs.final_report ignored value from table_ignore_organisation'
 );
 

--- a/test/unit/materialized_view_final_report_test.sql
+++ b/test/unit/materialized_view_final_report_test.sql
@@ -120,10 +120,10 @@ refresh materialized view ggircs_swrs.final_report with data;
 
 -- Test ghgr_import_id fk relation
 select results_eq(
-    'select report.swrs_report_id from ggircs_swrs.final_report ' ||
-    'join ggircs_swrs.report ' ||
-    'on ' ||
-    'final_report.swrs_report_id = report.swrs_report_id ',
+    $$select report.swrs_report_id from ggircs_swrs.final_report
+    join ggircs_swrs.report
+    on
+    final_report.swrs_report_id = report.swrs_report_id $$,
 
     'select swrs_report_id from ggircs_swrs.report',
 

--- a/test/unit/materialized_view_flat_test.sql
+++ b/test/unit/materialized_view_flat_test.sql
@@ -72,10 +72,12 @@ refresh materialized view ggircs_swrs.flat with data;
 -- test the fk relation to ghgr_import
 --  Test ghgr_import_id fk relation
 select results_eq(
-    $$select ghgr_import.id from ggircs_swrs.flat
+    $$
+    select ghgr_import.id from ggircs_swrs.flat
     join ggircs_swrs.ghgr_import
     on
-    flat.ghgr_import_id =  ghgr_import.id limit 1 $$,
+    flat.ghgr_import_id =  ghgr_import.id limit 1
+    $$,
 
     'select id from ggircs_swrs.ghgr_import',
 
@@ -83,7 +85,10 @@ select results_eq(
 );
 
 -- test the columnns for matview facility have been properly parsed from xml
-select results_eq('select * from ggircs_swrs.flat', $$
+select results_eq(
+  'select * from ggircs_swrs.flat',
+
+  $$
   with _flat as (
     select * from (
       values
@@ -97,7 +102,9 @@ select results_eq('select * from ggircs_swrs.flat', $$
     as flat (element_id, class, attr, value, context)
   )
   select ghgr_import.id, _flat.* from _flat, ggircs_swrs.ghgr_import;
-$$, 'ggircs_swrs.flat() should return all xml nodes with values as rows');
+  $$,
+
+  'ggircs_swrs.flat() should return all xml nodes with values as rows');
 
 select finish();
 rollback;

--- a/test/unit/materialized_view_flat_test.sql
+++ b/test/unit/materialized_view_flat_test.sql
@@ -72,10 +72,10 @@ refresh materialized view ggircs_swrs.flat with data;
 -- test the fk relation to ghgr_import
 --  Test ghgr_import_id fk relation
 select results_eq(
-    'select ghgr_import.id from ggircs_swrs.flat ' ||
-    'join ggircs_swrs.ghgr_import ' ||
-    'on ' ||
-    'flat.ghgr_import_id =  ghgr_import.id limit 1',
+    $$select ghgr_import.id from ggircs_swrs.flat
+    join ggircs_swrs.ghgr_import
+    on
+    flat.ghgr_import_id =  ghgr_import.id limit 1 $$,
 
     'select id from ggircs_swrs.ghgr_import',
 

--- a/test/unit/materialized_view_fuel_test.sql
+++ b/test/unit/materialized_view_fuel_test.sql
@@ -258,7 +258,8 @@ select results_eq(
 );
 
 select results_eq(
-    $$select unit.ghgr_import_id from ggircs_swrs.fuel
+    $$
+    select unit.ghgr_import_id from ggircs_swrs.fuel
     join ggircs_swrs.unit
     on (
     fuel.ghgr_import_id =  unit.ghgr_import_id
@@ -266,7 +267,8 @@ select results_eq(
     and fuel.sub_process_idx = unit.sub_process_idx
     and fuel.activity_name = unit.activity_name
     and fuel.units_idx = unit.units_idx
-    and fuel.unit_idx = unit.unit_idx)$$,
+    and fuel.unit_idx = unit.unit_idx)
+    $$,
 
     'select ghgr_import_id from ggircs_swrs.unit',
 

--- a/test/unit/materialized_view_fuel_test.sql
+++ b/test/unit/materialized_view_fuel_test.sql
@@ -258,15 +258,15 @@ select results_eq(
 );
 
 select results_eq(
-    'select unit.ghgr_import_id from ggircs_swrs.fuel ' ||
-    'join ggircs_swrs.unit ' ||
-    'on (' ||
-    'fuel.ghgr_import_id =  unit.ghgr_import_id ' ||
-    'and fuel.process_idx = unit.process_idx ' ||
-    'and fuel.sub_process_idx = unit.sub_process_idx ' ||
-    'and fuel.activity_name = unit.activity_name ' ||
-    'and fuel.units_idx = unit.units_idx ' ||
-    'and fuel.unit_idx = unit.unit_idx)',
+    $$select unit.ghgr_import_id from ggircs_swrs.fuel
+    join ggircs_swrs.unit
+    on (
+    fuel.ghgr_import_id =  unit.ghgr_import_id
+    and fuel.process_idx = unit.process_idx
+    and fuel.sub_process_idx = unit.sub_process_idx
+    and fuel.activity_name = unit.activity_name
+    and fuel.units_idx = unit.units_idx
+    and fuel.unit_idx = unit.unit_idx)$$,
 
     'select ghgr_import_id from ggircs_swrs.unit',
 

--- a/test/unit/materialized_view_measured_emission_factor_test.sql
+++ b/test/unit/materialized_view_measured_emission_factor_test.sql
@@ -140,7 +140,8 @@ select results_eq(
 
 -- measured_emission_factor -> fuel
 select results_eq(
-    $$select fuel.ghgr_import_id from ggircs_swrs.measured_emission_factor
+    $$
+    select fuel.ghgr_import_id from ggircs_swrs.measured_emission_factor
     join ggircs_swrs.fuel
     on (
     measured_emission_factor.ghgr_import_id =  fuel.ghgr_import_id
@@ -149,7 +150,8 @@ select results_eq(
     and measured_emission_factor.activity_name = fuel.activity_name
     and measured_emission_factor.units_idx = fuel.units_idx
     and measured_emission_factor.unit_idx = fuel.unit_idx)
-    and measured_emission_factor.fuel_idx = fuel.fuel_idx$$,
+    and measured_emission_factor.fuel_idx = fuel.fuel_idx
+    $$,
 
     'select ghgr_import_id from ggircs_swrs.fuel',
 

--- a/test/unit/materialized_view_measured_emission_factor_test.sql
+++ b/test/unit/materialized_view_measured_emission_factor_test.sql
@@ -140,16 +140,16 @@ select results_eq(
 
 -- measured_emission_factor -> fuel
 select results_eq(
-    'select fuel.ghgr_import_id from ggircs_swrs.measured_emission_factor ' ||
-    'join ggircs_swrs.fuel ' ||
-    'on (' ||
-    'measured_emission_factor.ghgr_import_id =  fuel.ghgr_import_id ' ||
-    'and measured_emission_factor.process_idx = fuel.process_idx ' ||
-    'and measured_emission_factor.sub_process_idx = fuel.sub_process_idx ' ||
-    'and measured_emission_factor.activity_name = fuel.activity_name ' ||
-    'and measured_emission_factor.units_idx = fuel.units_idx ' ||
-    'and measured_emission_factor.unit_idx = fuel.unit_idx)' ||
-    'and measured_emission_factor.fuel_idx = fuel.fuel_idx',
+    $$select fuel.ghgr_import_id from ggircs_swrs.measured_emission_factor
+    join ggircs_swrs.fuel
+    on (
+    measured_emission_factor.ghgr_import_id =  fuel.ghgr_import_id
+    and measured_emission_factor.process_idx = fuel.process_idx
+    and measured_emission_factor.sub_process_idx = fuel.sub_process_idx
+    and measured_emission_factor.activity_name = fuel.activity_name
+    and measured_emission_factor.units_idx = fuel.units_idx
+    and measured_emission_factor.unit_idx = fuel.unit_idx)
+    and measured_emission_factor.fuel_idx = fuel.fuel_idx$$,
 
     'select ghgr_import_id from ggircs_swrs.fuel',
 

--- a/test/unit/materialized_view_naics_test.sql
+++ b/test/unit/materialized_view_naics_test.sql
@@ -63,10 +63,12 @@ refresh materialized view ggircs_swrs.naics with data;
 
 --  Test the foreign key join on facility
 select results_eq(
-    $$select facility.ghgr_import_id from ggircs_swrs.naics
+    $$
+    select facility.ghgr_import_id from ggircs_swrs.naics
     join ggircs_swrs.facility
     on
-    naics.ghgr_import_id = facility.ghgr_import_id $$,
+    naics.ghgr_import_id = facility.ghgr_import_id
+    $$,
 
     'select ghgr_import_id from ggircs_swrs.facility',
 

--- a/test/unit/materialized_view_naics_test.sql
+++ b/test/unit/materialized_view_naics_test.sql
@@ -63,10 +63,10 @@ refresh materialized view ggircs_swrs.naics with data;
 
 --  Test the foreign key join on facility
 select results_eq(
-    'select facility.ghgr_import_id from ggircs_swrs.naics ' ||
-    'join ggircs_swrs.facility ' ||
-    'on ' ||
-    'naics.ghgr_import_id = facility.ghgr_import_id ',
+    $$select facility.ghgr_import_id from ggircs_swrs.naics
+    join ggircs_swrs.facility
+    on
+    naics.ghgr_import_id = facility.ghgr_import_id $$,
 
     'select ghgr_import_id from ggircs_swrs.facility',
 

--- a/test/unit/materialized_view_organisation_test.sql
+++ b/test/unit/materialized_view_organisation_test.sql
@@ -73,10 +73,12 @@ refresh materialized view ggircs_swrs.organisation with data;
 
 --  Test ghgr_import_id fk relation
 select results_eq(
-    $$select ghgr_import.id from ggircs_swrs.organisation
+    $$
+    select ghgr_import.id from ggircs_swrs.organisation
     join ggircs_swrs.ghgr_import
     on
-    organisation.ghgr_import_id =  ghgr_import.id $$,
+    organisation.ghgr_import_id =  ghgr_import.id
+    $$,
 
     'select id from ggircs_swrs.ghgr_import',
 

--- a/test/unit/materialized_view_organisation_test.sql
+++ b/test/unit/materialized_view_organisation_test.sql
@@ -73,10 +73,10 @@ refresh materialized view ggircs_swrs.organisation with data;
 
 --  Test ghgr_import_id fk relation
 select results_eq(
-    'select ghgr_import.id from ggircs_swrs.organisation ' ||
-    'join ggircs_swrs.ghgr_import ' ||
-    'on ' ||
-    'organisation.ghgr_import_id =  ghgr_import.id ',
+    $$select ghgr_import.id from ggircs_swrs.organisation
+    join ggircs_swrs.ghgr_import
+    on
+    organisation.ghgr_import_id =  ghgr_import.id $$,
 
     'select id from ggircs_swrs.ghgr_import',
 

--- a/test/unit/materialized_view_parent_organisation_test.sql
+++ b/test/unit/materialized_view_parent_organisation_test.sql
@@ -98,10 +98,10 @@ refresh materialized view ggircs_swrs.organisation with data;
 refresh materialized view ggircs_swrs.parent_organisation with data;
 
 select results_eq(
-    'select organisation.ghgr_import_id from ggircs_swrs.parent_organisation ' ||
-    'join ggircs_swrs.organisation ' ||
-    'on ' ||
-    'parent_organisation.ghgr_import_id = organisation.ghgr_import_id',
+     $$select organisation.ghgr_import_id from ggircs_swrs.parent_organisation
+     join ggircs_swrs.organisation
+     on
+     parent_organisation.ghgr_import_id = organisation.ghgr_import_id$$,
 
     'select ghgr_import_id from ggircs_swrs.organisation',
 

--- a/test/unit/materialized_view_parent_organisation_test.sql
+++ b/test/unit/materialized_view_parent_organisation_test.sql
@@ -98,10 +98,12 @@ refresh materialized view ggircs_swrs.organisation with data;
 refresh materialized view ggircs_swrs.parent_organisation with data;
 
 select results_eq(
-     $$select organisation.ghgr_import_id from ggircs_swrs.parent_organisation
+     $$
+     select organisation.ghgr_import_id from ggircs_swrs.parent_organisation
      join ggircs_swrs.organisation
      on
-     parent_organisation.ghgr_import_id = organisation.ghgr_import_id$$,
+     parent_organisation.ghgr_import_id = organisation.ghgr_import_id
+     $$,
 
     'select ghgr_import_id from ggircs_swrs.organisation',
 

--- a/test/unit/materialized_view_permit_test.sql
+++ b/test/unit/materialized_view_permit_test.sql
@@ -79,10 +79,12 @@ refresh materialized view ggircs_swrs.facility with data;
 refresh materialized view ggircs_swrs.permit with data;
 
 select results_eq(
-     $$select facility.swrs_facility_id from ggircs_swrs.permit
+     $$
+     select facility.swrs_facility_id from ggircs_swrs.permit
      join ggircs_swrs.facility
      on
-     permit.ghgr_import_id = facility.ghgr_import_id$$,
+     permit.ghgr_import_id = facility.ghgr_import_id
+     $$,
 
     'select swrs_facility_id from ggircs_swrs.facility',
 

--- a/test/unit/materialized_view_permit_test.sql
+++ b/test/unit/materialized_view_permit_test.sql
@@ -79,10 +79,10 @@ refresh materialized view ggircs_swrs.facility with data;
 refresh materialized view ggircs_swrs.permit with data;
 
 select results_eq(
-    'select facility.swrs_facility_id from ggircs_swrs.permit ' ||
-    'join ggircs_swrs.facility ' ||
-    'on ' ||
-    'permit.ghgr_import_id = facility.ghgr_import_id',
+     $$select facility.swrs_facility_id from ggircs_swrs.permit
+     join ggircs_swrs.facility
+     on
+     permit.ghgr_import_id = facility.ghgr_import_id$$,
 
     'select swrs_facility_id from ggircs_swrs.facility',
 

--- a/test/unit/materialized_view_unit_test.sql
+++ b/test/unit/materialized_view_unit_test.sql
@@ -180,13 +180,15 @@ refresh materialized view ggircs_swrs.activity with data;
 
 -- test the foreign keys in unit return a value when joined on activity
 select results_eq(
-    $$select activity.ghgr_import_id from ggircs_swrs.unit
+    $$
+    select activity.ghgr_import_id from ggircs_swrs.unit
      join ggircs_swrs.activity
      on (
      unit.ghgr_import_id =  activity.ghgr_import_id
      and unit.process_idx = activity.process_idx
      and unit.sub_process_idx = activity.sub_process_idx
-     and unit.activity_name = activity.activity_name)$$,
+     and unit.activity_name = activity.activity_name)
+    $$,
 
     'select ghgr_import_id from ggircs_swrs.activity',
 

--- a/test/unit/materialized_view_unit_test.sql
+++ b/test/unit/materialized_view_unit_test.sql
@@ -180,13 +180,13 @@ refresh materialized view ggircs_swrs.activity with data;
 
 -- test the foreign keys in unit return a value when joined on activity
 select results_eq(
-    'select activity.ghgr_import_id from ggircs_swrs.unit ' ||
-    'join ggircs_swrs.activity ' ||
-    'on (' ||
-    'unit.ghgr_import_id =  activity.ghgr_import_id ' ||
-    'and unit.process_idx = activity.process_idx ' ||
-    'and unit.sub_process_idx = activity.sub_process_idx ' ||
-    'and unit.activity_name = activity.activity_name)',
+    $$select activity.ghgr_import_id from ggircs_swrs.unit
+     join ggircs_swrs.activity
+     on (
+     unit.ghgr_import_id =  activity.ghgr_import_id
+     and unit.process_idx = activity.process_idx
+     and unit.sub_process_idx = activity.sub_process_idx
+     and unit.activity_name = activity.activity_name)$$,
 
     'select ghgr_import_id from ggircs_swrs.activity',
 


### PR DESCRIPTION
@wenzowski @hamzajaved 
I've cleaned up the linebreaks in all the files that were broken up with || and blocked them together with $$. If either of you have more sweeping formatting changes that you'd like to see done before this sprint pop em in a comment.