### PR TITLE
Fix metabase docker image user and ownership of home dir

### DIFF
--- a/docker/metabase/Dockerfile
+++ b/docker/metabase/Dockerfile
@@ -9,3 +9,9 @@ RUN yum install -y java-1.8.0-openjdk && yum clean all
 COPY metabase.jar .
 
 ENTRYPOINT ["java", "-jar", "metabase.jar"]
+
+# Drop the root user and make the content of /opt/app-root owned by user 1001
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
+    rpm-file-permissions
+
+USER 1001


### PR DESCRIPTION
Metabase was printing the following warning when intializing:

```
WARN metabase.plugins :: Metabase cannot use the plugins directory /opt/app-root/src/plugins 
 Please make sure the directory exists and that Metabase has permission to write to it. 
You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR. 
Falling back to a temporary directory for now.
```