### PR TITLE
automatically revert/deploy via sqitch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ define switch_project
 endef
 
 define oc_process
-	@@${OC} process -f openshift/${1}.yml ${2} | ${OC} apply --wait=true -f-
+	@@${OC} process -f openshift/${1}.yml ${2} | ${OC} apply --wait=true --overwrite=true -f-
 endef
 
 define build
@@ -245,8 +245,6 @@ define deploy
 	$(call oc_process,service/cas-ggircs-metabase-postgres,)
 	$(call oc_process,service/cas-ggircs-metabase,)
 	$(call oc_process,route/cas-ggircs-metabase,OC_PROJECT=${OC_PROJECT})
-	# Migrate...
-	# TODO(wenzowski): automatically run a `sqitch deploy`
 endef
 
 .PHONY: deploy_tools

--- a/openshift/deploymentconfig/cas-ggircs.yml
+++ b/openshift/deploymentconfig/cas-ggircs.yml
@@ -2,6 +2,35 @@ apiVersion: template.openshift.io/v1
 kind: Template
 labels:
   template: deploy-template
+
+envDefaults: &envDefaults
+  env:
+    - name: SQITCH_TARGET
+      value: "db:pg:"
+    - name: PGUSER
+      valueFrom:
+        secretKeyRef:
+          key: database-user
+          name: cas-ggircs-postgres
+    - name: PGPASSWORD
+      valueFrom:
+        secretKeyRef:
+          key: database-password
+          name: cas-ggircs-postgres
+    - name: PGDATABASE
+      valueFrom:
+        secretKeyRef:
+          key: database-name
+          name: cas-ggircs-postgres
+    - name: PGPORT
+      value: "5432"
+    - name: PGHOST
+      value: cas-ggircs-postgres
+    - name: SQITCH_FULLNAME
+      value: OpenShift Deployer
+    - name: SQITCH_EMAIL
+      value: deployer@pathfinder.gov.bc.ca
+
 objects:
 
 - apiVersion: v1
@@ -16,6 +45,32 @@ objects:
       name: cas-ggircs
     strategy:
       type: Rolling
+      rollingParams:
+        pre:
+          failurePolicy: Retry
+          execNewPod:
+            <<: *envDefaults
+            containerName: cas-ggircs
+            command:
+              - /usr/bin/env
+              - bash
+              - -c
+              - |
+                sqitch revert table_ghgr_import -y;
+        post:
+          failurePolicy: Retry
+          execNewPod:
+            <<: *envDefaults
+            containerName: cas-ggircs
+            command:
+              - /usr/bin/env
+              - bash
+              - -c
+              - |
+                set -euo pipefail;
+                sqitch deploy;
+                echo "Exporting data to `ggircs` schema";
+                psql -c "select ggircs_swrs.export_mv_to_table()";
     template:
       metadata:
         labels:
@@ -23,32 +78,7 @@ objects:
       spec:
         containers:
         - capabilities: {}
-          env:
-          - name: SQITCH_TARGET
-            value: "db:pg:"
-          - name: PGUSER
-            valueFrom:
-              secretKeyRef:
-                key: database-user
-                name: cas-ggircs-postgres
-          - name: PGPASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: database-password
-                name: cas-ggircs-postgres
-          - name: PGDATABASE
-            valueFrom:
-              secretKeyRef:
-                key: database-name
-                name: cas-ggircs-postgres
-          - name: PGPORT
-            value: "5432"
-          - name: PGHOST
-            value: cas-ggircs-postgres
-          - name: SQITCH_FULLNAME
-            value: OpenShift Deployer
-          - name: SQITCH_EMAIL
-            value: deployer@pathfinder.gov.bc.ca
+          <<: *envDefaults
           image: cas-ggircs-mirror:latest
           imagePullPolicy: IfNotPresent
           name: cas-ggircs


### PR DESCRIPTION
will be more efficient when sqitchers/sqitch#477 lands, and will result in less downtime during redeploys

Probably also want to run the exporter function via psql on each deploy, in addition to via cron