### PR TITLE
Use sqitch version with --revised feature

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -e
+
+shopt -s dotglob
+echo "---> Installing application source ..."
+mv /tmp/src/* ./
+
+if [ -d ./cfg ]; then
+  echo "---> Copying configuration files..."
+  if [ "$(ls -A ./cfg/*.conf)" ]; then
+    cp -v ./cfg/*.conf /opt/app-root/etc/httpd.d/
+  fi
+fi
+
+# Allow for http proxy to be specified in uppercase
+if [[ -n "${HTTP_PROXY:-}" && -z "${http_proxy:-}" ]]; then
+  export http_proxy=$HTTP_PROXY
+fi
+
+export CPAN_MIRROR=${CPAN_MIRROR:-""}
+
+MIRROR_ARGS=""
+
+if [ -n "$CPAN_MIRROR" ]; then
+  MIRROR_ARGS="--mirror $CPAN_MIRROR"
+fi
+
+# Don't test installed Perl modules by default
+if [ "${ENABLE_CPAN_TEST}" = true ]; then
+  export ENABLE_CPAN_TEST=""
+else
+  export ENABLE_CPAN_TEST="--notest"
+fi
+
+# Configure mod_perl for PSGI.
+# If PSGI_FILE variable is set but empty, skip it.
+# If PSGI_FILE is set and non-empty, use it.
+# If PSGI_FILE does not exist, check if exactly one ./*.psgi file exists and
+# use that file.
+# If PSGI_URI_PATH variable has a value, use it as a location. Default is "/".
+if [ ! -v PSGI_FILE ]; then
+    PSGI_FILE=$(find -maxdepth 1 -name '*.psgi' -type f)
+fi
+PSGI_FILE_NUMBER=$(printf '%s' "$PSGI_FILE" | wc -l)
+if [ -n "$PSGI_FILE" -a "$PSGI_FILE_NUMBER" -eq 0 ]; then
+    echo "---> PSGI application found in $PSGI_FILE"
+    cat >> cpanfile <<"EOF"
+requires 'Plack::Handler::Apache2';
+EOF
+    # XXX: Escape PSGI_FILE value against httpd control characters
+    PSGI_FILE=$(printf '%s' "$PSGI_FILE" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+    cat > /opt/app-root/etc/httpd.d/40-psgi.conf <<EOF
+<Location ${PSGI_URI_PATH:=/}>
+    SetHandler perl-script
+    PerlResponseHandler Plack::Handler::Apache2
+    PerlSetVar psgi_app "$PSGI_FILE"
+</Location>
+EOF
+elif [ "$PSGI_FILE_NUMBER" -gt 0 ]; then
+    echo "---> Multiple PSGI applications found:"
+    printf '%s' "$PSGI_FILE"
+    echo "---> Skipping PSGI autoconfiguration!"
+fi
+
+# Installing dependencies with cpanfile
+if [ -f "cpanfile" ]; then
+  echo "---> Installing modules from cpanfile ..."
+  cpanm $MIRROR_ARGS $ENABLE_CPAN_TEST -l extlib Module::CoreList
+  # Installing Sqitch from url
+  cpanm $MIRROR_ARGS $ENABLE_CPAN_TEST -l extlib https://github.com/matthieu-foucault/sqitch/releases/download/v1.0.1.TRIAL/App-Sqitch-v1.0.1-TRIAL.tar.gz
+  cpanm $MIRROR_ARGS $ENABLE_CPAN_TEST -l extlib --installdeps .
+else
+  echo "---> No cpanfile found, nothing to install"
+fi
+
+# Fix source directory permissions
+fix-permissions ./

--- a/Makefile
+++ b/Makefile
@@ -164,15 +164,6 @@ else
 	@@$(MAKE) -C pgtap -s $(MAKEFLAGS) install
 endif
 
-.PHONY: install_sqitch
-install_sqitch:
-	# install postgres driver for sqitch
-	@@${CPAN} DBD::Pg
-	# install sqitch
-	@@${CPAN} App::Sqitch
-	# install pg_prove
-	@@${CPAN} TAP::Parser::SourceHandler::pgTAP
-
 .PHONY: install_cpanm
 install_cpanm:
 ifeq (${shell which ${CPANM}},)
@@ -182,6 +173,8 @@ endif
 
 .PHONY: install_cpandeps
 install_cpandeps:
+	# install sqitch
+	${CPANM} -n https://github.com/matthieu-foucault/sqitch/releases/download/v1.0.1.TRIAL/App-Sqitch-v1.0.1-TRIAL.tar.gz
 	# install Perl dependencies from cpanfile
 	${CPANM} --installdeps .
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,4 @@
 requires 'DBD::Pg', '== 3.8.0';
-requires 'App::Sqitch', '== 0.9999';
+requires 'App::Sqitch', '== 1.0.1',
+    url => 'https://github.com/matthieu-foucault/sqitch/releases/download/v1.0.1.TRIAL/App-Sqitch-v1.0.1-TRIAL.tar.gz';
 requires 'TAP::Parser::SourceHandler::pgTAP', '== 3.35';

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,3 @@
 requires 'DBD::Pg', '== 3.8.0';
-requires 'App::Sqitch', '== 1.0.1',
-    url => 'https://github.com/matthieu-foucault/sqitch/releases/download/v1.0.1.TRIAL/App-Sqitch-v1.0.1-TRIAL.tar.gz';
+requires 'App::Sqitch', '== 1.0.1';
 requires 'TAP::Parser::SourceHandler::pgTAP', '== 3.35';


### PR DESCRIPTION
Devs can run `make install_cpandeps` to install the latest version of sqitch. The `rebase --revised` feature is not in use in the deployment config as it requires the export function to be able to do a partial export