### PR TITLE
pinned git references should be respected

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,7 @@ jobs:
       - run:
           name: "Pull Submodules"
           command: |
-            git submodule init
-            git submodule update --remote
+            git submodule update --init
       - run:
           name: Create testing db
           command: |
@@ -89,8 +88,7 @@ jobs:
       - run:
           name: "Pull Submodules"
           command: |
-            git submodule init
-            git submodule update --remote
+            git submodule update --init
       - redhat-openshift/login-and-update-kubeconfig:
           insecure-skip-tls-verify: true
           openshift-platform-version: 3.x
@@ -107,8 +105,7 @@ jobs:
       - run:
           name: "Pull Submodules"
           command: |
-            git submodule init
-            git submodule update --remote
+            git submodule update --init
       - redhat-openshift/login-and-update-kubeconfig:
           insecure-skip-tls-verify: true
           openshift-platform-version: 3.x

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,5 +1,4 @@
 deploy:
   override:
-    - git submodule --quiet init
-    - git submodule --quiet update --remote
+    - git submodule update --init --quiet
     - make install


### PR DESCRIPTION
When running non-interactively, git submodules should always be checked
out exactly as committed. The `git submodule update --remote` command
should be use interactively to fetch the latest head of all submodules
per the gitmodules config and if any referenceds have changed they
should be committed manually.