### PR TITLE
Properly type reporting_period_duration as integer

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,4 @@
+nodejs 10.14.1
+yarn 1.12.3
+postgres 11.4
+python 3.7.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,1 @@
-nodejs 10.14.1
-yarn 1.12.3
 postgres 11.4
-python 3.7.0

--- a/deploy/swrs/public/table/report.sql
+++ b/deploy/swrs/public/table/report.sql
@@ -14,7 +14,7 @@ create table swrs.report
     report_type               varchar(1000),
     swrs_facility_id          integer,
     swrs_organisation_id      integer,
-    reporting_period_duration varchar(1000),
+    reporting_period_duration integer,
     status                    varchar(1000),
     version                   varchar(1000),
     submission_date           timestamptz,

--- a/deploy/swrs/public/view/carbon_tax_calculation.sql
+++ b/deploy/swrs/public/view/carbon_tax_calculation.sql
@@ -17,7 +17,7 @@ create or replace view swrs.carbon_tax_calculation as
                _naics.id                                                     as naics_id,
                _fuel_mapping.fuel_type                                       as fuel_type,
                coalesce(_fuel.annual_fuel_amount, _emission.quantity)        as fuel_amount,
-               _report.reporting_period_duration::integer as year,
+               _report.reporting_period_duration as year,
                _pro_rated_fuel_charge.pro_rated_fuel_charge,
                _pro_rated_fuel_charge.flat_rate,
                _fuel_carbon_tax_details.cta_rate_units                      as units,

--- a/deploy/swrs/public/view/pro_rated_carbon_tax_rate.sql
+++ b/deploy/swrs/public/view/pro_rated_carbon_tax_rate.sql
@@ -11,7 +11,7 @@ begin;
 create or replace view swrs.pro_rated_carbon_tax_rate as
     with x as (
         select fuel.fuel_type                   as fuel_type,
-               report.reporting_period_duration::integer as rpd,
+               report.reporting_period_duration as rpd,
                ctr.rate_start_date              as start,
                ctr.rate_end_date                as end,
                ctr.carbon_tax_rate              as rate,
@@ -20,10 +20,10 @@ create or replace view swrs.pro_rated_carbon_tax_rate as
                  join swrs.report as report
                       on fuel.ghgr_import_id = report.ghgr_import_id
                  join swrs.carbon_tax_rate_mapping as ctr
-                      on concat((report.reporting_period_duration::integer - 1)::text, '-04-01')::date >= ctr.rate_start_date
+                      on concat((report.reporting_period_duration - 1)::text, '-04-01')::date >= ctr.rate_start_date
                       and concat(report.reporting_period_duration::text, '-03-31')::date <= ctr.rate_end_date
     ), y as (
-    select x.rpd::integer as reporting_year,
+    select x.rpd as reporting_year,
            x.fuel_type as fuel_type,
            case
                when x.rpd > 2021 then (select carbon_tax_rate from swrs.carbon_tax_rate_mapping where id = (select max(id) from swrs.carbon_tax_rate_mapping))

--- a/deploy/swrs/public/view/pro_rated_fuel_charge.sql
+++ b/deploy/swrs/public/view/pro_rated_fuel_charge.sql
@@ -10,7 +10,7 @@ create or replace view swrs.pro_rated_fuel_charge as
     with x as (
         select _fuel_mapping.fuel_type,
                coalesce(fuel.fuel_mapping_id, _emission.fuel_mapping_id)        as fuel_mapping_id,
-               _report.reporting_period_duration::integer                       as year,
+               _report.reporting_period_duration                                as year,
                _fuel_charge.start_date,
                _fuel_charge.end_date,
                _fuel_charge.fuel_charge,

--- a/deploy/swrs/public/view/pro_rated_implied_emission_factor.sql
+++ b/deploy/swrs/public/view/pro_rated_implied_emission_factor.sql
@@ -11,7 +11,7 @@ begin;
 create or replace view swrs.pro_rated_implied_emission_factor as
     with x as (
         select fuel.fuel_type                   as fuel_type,
-               report.reporting_period_duration::integer as rpd,
+               report.reporting_period_duration as rpd,
                fmap.id                           as fmap_id,
                ief.start_date                   as start,
                ief.end_date                     as end,
@@ -25,7 +25,7 @@ create or replace view swrs.pro_rated_implied_emission_factor as
                       on fuel.fuel_type = fmap.fuel_type
                  join swrs.implied_emission_factor as ief
                       on ief.fuel_mapping_id = fmap.id
-                      and concat((report.reporting_period_duration::integer - 1)::text, '-04-01')::date >= ief.start_date
+                      and concat((report.reporting_period_duration - 1)::text, '-04-01')::date >= ief.start_date
                       and concat(report.reporting_period_duration::text, '-03-31')::date <= ief.end_date
 
     ), y as (

--- a/deploy/swrs/transform/materialized_view/report.sql
+++ b/deploy/swrs/transform/materialized_view/report.sql
@@ -15,7 +15,7 @@ create materialized view swrs_transform.report as (
     report_details.report_type,
     report_details.swrs_facility_id,
     report_details.swrs_organisation_id,
-    (regexp_matches(report_details.reporting_period_duration, '\d\d\d\d'))[1]::varchar(1000) as reporting_period_duration,
+    (regexp_matches(report_details.reporting_period_duration::varchar(1000), '\d\d\d\d'))[1]::integer as reporting_period_duration,
     report_status.*
   from swrs_extract.ghgr_import,
        xmltable(
@@ -27,7 +27,7 @@ create materialized view swrs_transform.report as (
              report_type varchar(1000) path 'ReportType[normalize-space(.)]' not null,
              swrs_facility_id integer path 'FacilityId[normalize-space(.)]' not null,
              swrs_organisation_id integer path 'OrganisationId[normalize-space(.)]' not null,
-             reporting_period_duration varchar(1000) path 'ReportingPeriodDuration[normalize-space(.)]' not null
+             reporting_period_duration integer path 'ReportingPeriodDuration[normalize-space(.)]' not null
          ) as report_details,
 
        xmltable(

--- a/test/unit/materialized_view_report_test.sql
+++ b/test/unit/materialized_view_report_test.sql
@@ -38,7 +38,7 @@ select col_type_is('swrs_transform', 'report', 'prepop_report_id', 'integer', 'M
 select col_type_is('swrs_transform', 'report', 'report_type', 'character varying(1000)', 'Matview report column report_type has type character varying(1000)');
 select col_type_is('swrs_transform', 'report', 'swrs_facility_id', 'integer', 'Matview report column swrs_facility_id has type integer');
 select col_type_is('swrs_transform', 'report', 'swrs_organisation_id', 'integer', 'Matview report column swrs_organisation_id has type integer');
-select col_type_is('swrs_transform', 'report', 'reporting_period_duration', 'character varying(1000)', 'Matview report column reporting_period_duration has type numeric(1000,0)');
+select col_type_is('swrs_transform', 'report', 'reporting_period_duration', 'integer', 'Matview report column reporting_period_duration has type int');
 select col_type_is('swrs_transform', 'report', 'status', 'character varying(1000)', 'Matview report column status has type character varying(1000)');
 select col_type_is('swrs_transform', 'report', 'version', 'character varying(1000)', 'Matview report column version has type character varying(1000)');
 select col_type_is('swrs_transform', 'report', 'submission_date', 'timestamp with time zone', 'Matview report column submission_date has type character varying(1000)');
@@ -93,7 +93,7 @@ select results_eq('select prepop_report_id from swrs_transform.report', ARRAY[nu
 select results_eq('select report_type from swrs_transform.report', ARRAY['R7'::varchar], 'Matview report parsed column report_type');
 select results_eq('select swrs_facility_id from swrs_transform.report', ARRAY[666::integer], 'Matview report parsed column swrs_facility_id');
 select results_eq('select swrs_organisation_id from swrs_transform.report', ARRAY[1337::integer], 'Matview report parsed column swrs_organisation_id');
-select results_eq('select reporting_period_duration from swrs_transform.report', ARRAY[1999::varchar], 'Matview report parsed column reporting_period_duration');
+select results_eq('select reporting_period_duration from swrs_transform.report', ARRAY[1999::integer], 'Matview report parsed column reporting_period_duration');
 select results_eq('select status from swrs_transform.report', ARRAY['In Progress'::varchar], 'Matview report parsed column status');
 select results_eq('select version from swrs_transform.report', ARRAY[3::varchar], 'Matview report parsed column version');
 select results_eq('select submission_date from swrs_transform.report', ARRAY[null::timestamptz], 'Matview report parsed column submission_date');

--- a/test/unit/view_attributable_emission_with_details_test.sql
+++ b/test/unit/view_attributable_emission_with_details_test.sql
@@ -87,7 +87,7 @@ select col_hasnt_default('swrs', 'attributable_emissions_with_details', 'methodo
 select col_type_is('swrs', 'attributable_emissions_with_details', 'emission_category', 'character varying(1000)', 'attributable_emissions.emission_category column should be type varchar');
 select col_hasnt_default('swrs', 'attributable_emissions_with_details', 'emission_category', 'attributable_emission.emission_category column should not have a default value');
 
-select col_type_is('swrs', 'attributable_emissions_with_details', 'reporting_period_duration', 'character varying(1000)', 'attributable_emissions.reporting_period_duration column should be type varchar');
+select col_type_is('swrs', 'attributable_emissions_with_details', 'reporting_period_duration', 'integer', 'attributable_emissions.reporting_period_duration column should be type varchar');
 select col_hasnt_default('swrs', 'attributable_emissions_with_details', 'reporting_period_duration', 'attributable_emission.reporting_period_duration column should not have a default value');
 
 select col_type_is('swrs', 'attributable_emissions_with_details', 'fuel_type', 'character varying(1000)', 'attributable_emissions.fuel_type column should be type varchar');

--- a/test/unit/view_pro_rated_carbon_tax_rate_DEPRECATED.sql
+++ b/test/unit/view_pro_rated_carbon_tax_rate_DEPRECATED.sql
@@ -152,7 +152,7 @@ select results_eq(
     'select reporting_year from swrs.pro_rated_carbon_tax_rate order by reporting_year',
 
     $$
-    select reporting_period_duration::integer
+    select reporting_period_duration
     from swrs_transform.fuel as fuel
     join swrs_transform.report as report
     on report.ghgr_import_id = fuel.ghgr_import_id
@@ -172,7 +172,7 @@ select results_eq(
     join swrs_transform.report as report
     on report.ghgr_import_id = fuel.ghgr_import_id
     )
-    select concat((x.rpd::integer)::text, '-12-31')::date - concat((x.rpd::integer)::text, '-01-01')::date as year_length
+    select concat((x.rpd)::text, '-12-31')::date - concat((x.rpd)::text, '-01-01')::date as year_length
     from x where x.fuel_type = 'Wood Waste'
     order by year_length
     $$,
@@ -190,13 +190,13 @@ select results_eq(
     join swrs_transform.report as report
         on report.ghgr_import_id = fuel.ghgr_import_id
     join swrs.carbon_tax_rate_mapping as ctr
-        on concat((report.reporting_period_duration::integer - 1)::text, '-04-01')::date >= ctr.rate_start_date
+        on concat((report.reporting_period_duration - 1)::text, '-04-01')::date >= ctr.rate_start_date
         and concat(report.reporting_period_duration::text, '-03-31')::date <= ctr.rate_end_date
     )
     select
            case
-               when x.rpd::integer <= 2017 then 0
-               when x.rpd::integer > 2021 then (select carbon_tax_rate from swrs.carbon_tax_rate_mapping where id = (select max(id) from swrs.carbon_tax_rate_mapping))
+               when x.rpd <= 2017 then 0
+               when x.rpd > 2021 then (select carbon_tax_rate from swrs.carbon_tax_rate_mapping where id = (select max(id) from swrs.carbon_tax_rate_mapping))
                else x.rate
            end as start_rate
     from x where x.fuel_type = 'Wood Waste' order by start_rate desc
@@ -215,17 +215,17 @@ select results_eq(
     join swrs_transform.report as report
         on report.ghgr_import_id = fuel.ghgr_import_id
     join swrs.carbon_tax_rate_mapping as ctr
-        on concat((report.reporting_period_duration::integer - 1)::text, '-04-01')::date >= ctr.rate_start_date
+        on concat((report.reporting_period_duration - 1)::text, '-04-01')::date >= ctr.rate_start_date
         and concat(report.reporting_period_duration::text, '-03-31')::date <= ctr.rate_end_date
     )
 
     select
         case
-            when x.rpd::integer <= 2017 then 0
-            when x.rpd::integer > 2021 then concat((x.rpd::integer)::text, '-04-01')::date - concat((x.rpd::integer)::text, '-01-01')::date
+            when x.rpd <= 2017 then 0
+            when x.rpd > 2021 then concat(x.rpd)::text, '-04-01')::date - concat((x.rpd)::text, '-01-01')::date
             else (select rate_start_date
                   from swrs.carbon_tax_rate_mapping
-                  where id = x.id+1) - concat((x.rpd::integer)::text, '-01-01')::date
+                  where id = x.id+1) - concat((x.rpd)::text, '-01-01')::date
         end as start_duration
     from x where x.fuel_type = 'Wood Waste' order by start_duration asc
     $$,
@@ -243,14 +243,14 @@ select results_eq(
     join swrs_transform.report as report
         on report.ghgr_import_id = fuel.ghgr_import_id
     join swrs.carbon_tax_rate_mapping as ctr
-        on concat((report.reporting_period_duration::integer - 1)::text, '-04-01')::date >= ctr.rate_start_date
+        on concat((report.reporting_period_duration - 1)::text, '-04-01')::date >= ctr.rate_start_date
         and concat(report.reporting_period_duration::text, '-03-31')::date <= ctr.rate_end_date
     )
     select
            case
-               when x.rpd::integer < 2017 then 0
-               when x.rpd::integer = 2017 then 30
-               when x.rpd::integer > 2021 then (select carbon_tax_rate from swrs.carbon_tax_rate_mapping where id = (select max(id) from swrs.carbon_tax_rate_mapping))
+               when x.rpd < 2017 then 0
+               when x.rpd = 2017 then 30
+               when x.rpd > 2021 then (select carbon_tax_rate from swrs.carbon_tax_rate_mapping where id = (select max(id) from swrs.carbon_tax_rate_mapping))
                else (select carbon_tax_rate from swrs.carbon_tax_rate_mapping where id = x.id+1)
            end as end_rate
     from x where x.fuel_type = 'Wood Waste' order by end_rate desc
@@ -269,15 +269,15 @@ select results_eq(
     join swrs_transform.report as report
         on report.ghgr_import_id = fuel.ghgr_import_id
     join swrs.carbon_tax_rate_mapping as ctr
-        on concat((report.reporting_period_duration::integer - 1)::text, '-04-01')::date >= ctr.rate_start_date
+        on concat((report.reporting_period_duration - 1)::text, '-04-01')::date >= ctr.rate_start_date
         and concat(report.reporting_period_duration::text, '-03-31')::date <= ctr.rate_end_date
     )
 
     select case
-               when x.rpd::integer < 2017 then 0
-               when x.rpd::integer = 2017 then '2017-12-31'::date - '2017-04-01'::date
-               when x.rpd::integer > 2021 then concat((x.rpd::integer)::text, '-12-31')::date - concat((x.rpd::integer)::text, '-04-01')::date
-               else concat((x.rpd::integer)::text, '-12-31')::date - (select rate_start_date
+               when x.rpd < 2017 then 0
+               when x.rpd = 2017 then '2017-12-31'::date - '2017-04-01'::date
+               when x.rpd > 2021 then concat((x.rpd)::text, '-12-31')::date - concat((x.rpd)::text, '-04-01')::date
+               else concat((x.rpd)::text, '-12-31')::date - (select rate_start_date
                                                              from swrs.carbon_tax_rate_mapping
                                                              where id = x.id+1)
            end as end_duration
@@ -302,42 +302,42 @@ select results_eq(
                  join swrs_transform.report as report
                       on fuel.ghgr_import_id = report.ghgr_import_id
                  join swrs.carbon_tax_rate_mapping as ctr
-                      on concat((report.reporting_period_duration::integer - 1)::text, '-04-01')::date >= ctr.rate_start_date
+                      on concat((report.reporting_period_duration - 1)::text, '-04-01')::date >= ctr.rate_start_date
                       and concat(report.reporting_period_duration::text, '-03-31')::date <= ctr.rate_end_date
     ), y as (
-    select x.rpd::integer as reporting_year,
+    select x.rpd as reporting_year,
            x.fuel_type as fuel_type,
            case
-               when x.rpd::integer <= 2017 then 0
-               when x.rpd::integer > 2021 then (select carbon_tax_rate from swrs.carbon_tax_rate_mapping where id = (select max(id) from swrs.carbon_tax_rate_mapping))
+               when x.rpd <= 2017 then 0
+               when x.rpd > 2021 then (select carbon_tax_rate from swrs.carbon_tax_rate_mapping where id = (select max(id) from swrs.carbon_tax_rate_mapping))
                else x.rate
            end as start_rate,
 
            case
-               when x.rpd::integer < 2017 then 0
-               when x.rpd::integer = 2017 then 30
-               when x.rpd::integer > 2021 then (select carbon_tax_rate from swrs.carbon_tax_rate_mapping where id = (select max(id) from swrs.carbon_tax_rate_mapping))
+               when x.rpd < 2017 then 0
+               when x.rpd = 2017 then 30
+               when x.rpd > 2021 then (select carbon_tax_rate from swrs.carbon_tax_rate_mapping where id = (select max(id) from swrs.carbon_tax_rate_mapping))
                else (select carbon_tax_rate from swrs.carbon_tax_rate_mapping where id = x.id+1)
            end as end_rate,
 
            case
-               when x.rpd::integer <= 2017 then 0
-               when x.rpd::integer > 2021 then concat((x.rpd::integer)::text, '-04-01')::date - concat((x.rpd::integer)::text, '-01-01')::date
+               when x.rpd <= 2017 then 0
+               when x.rpd > 2021 then concat((x.rpd)::text, '-04-01')::date - concat((x.rpd)::text, '-01-01')::date
                else (select rate_start_date
                      from swrs.carbon_tax_rate_mapping
-                     where id = x.id+1) - concat((x.rpd::integer)::text, '-01-01')::date
+                     where id = x.id+1) - concat((x.rpd)::text, '-01-01')::date
            end as start_duration,
 
            case
-               when x.rpd::integer < 2017 then 0
-               when x.rpd::integer = 2017 then '2017-12-31'::date - '2017-04-01'::date
-               when x.rpd::integer > 2021 then concat((x.rpd::integer)::text, '-12-31')::date - concat((x.rpd::integer)::text, '-04-01')::date
-               else concat((x.rpd::integer)::text, '-12-31')::date - (select rate_start_date
+               when x.rpd < 2017 then 0
+               when x.rpd = 2017 then '2017-12-31'::date - '2017-04-01'::date
+               when x.rpd > 2021 then concat((x.rpd)::text, '-12-31')::date - concat((x.rpd)::text, '-04-01')::date
+               else concat((x.rpd)::text, '-12-31')::date - (select rate_start_date
                                                              from swrs.carbon_tax_rate_mapping
                                                              where id = x.id+1)
            end as end_duration,
 
-           concat((x.rpd::integer)::text, '-12-31')::date - concat((x.rpd::integer)::text, '-01-01')::date as year_length
+           concat((x.rpd)::text, '-12-31')::date - concat((x.rpd)::text, '-01-01')::date as year_length
     from x)
     select
            ((y.start_rate * y.start_duration) + (y.end_rate * y.end_duration)) / y.year_length as pro_rated_carbon_tax_rate

--- a/test/unit/view_pro_rated_implied_emission_factor_DEPRECATED.sql
+++ b/test/unit/view_pro_rated_implied_emission_factor_DEPRECATED.sql
@@ -155,7 +155,7 @@ select results_eq(
     'select reporting_year from swrs.pro_rated_implied_emission_factor order by reporting_year',
 
     $$
-    select reporting_period_duration::integer
+    select reporting_period_duration
     from swrs.fuel as fuel
     join swrs.report as report
     on fuel.report_id = report.id

--- a/test/unit/view_report_with_org_test.sql
+++ b/test/unit/view_report_with_org_test.sql
@@ -39,7 +39,7 @@ select col_hasnt_default('swrs', 'report_with_org', 'facility_name', 'report_wit
 select col_type_is('swrs', 'report_with_org', 'facility_type', 'character varying(1000)', 'attributable_emissions.emission_id column should be type varchar');
 select col_hasnt_default('swrs', 'report_with_org', 'facility_type', 'report_with_org.facility_type column should not have a default value');
 
-select col_type_is('swrs', 'report_with_org', 'reporting_period_duration', 'character varying(1000)', 'attributable_emissions.emission_id column should be type varchar');
+select col_type_is('swrs', 'report_with_org', 'reporting_period_duration', 'integer', 'attributable_emissions.emission_id column should be type varchar');
 select col_hasnt_default('swrs', 'report_with_org', 'reporting_period_duration', 'report_with_org.reporting_period_duration column should not have a default value');
 
 select col_type_is('swrs', 'report_with_org', 'naics_classification', 'character varying(1000)', 'attributable_emissions.emission_id column should be type varchar');


### PR DESCRIPTION
- set reporting_period_duration to integer in report
- remove unnecessary casting to int in other files