### PR TITLE
test: ggircs needs the gluster-file storage type for its "data" PVC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ endif
 
 .PHONY: mock_storageclass
 mock_storageclass:
-	$(call oc_mock_storageclass,netapp-block-standard)
+	$(call oc_mock_storageclass,netapp-block-standard gluster-file)
 
 .PHONY: provision
 provision:


### PR DESCRIPTION
Looks like I deleted too many things in #144 