### PR TITLE
ci: don't drop eccc_xml_file table when deploying

### DIFF
--- a/openshift/deploy/job/etl-revert.yml
+++ b/openshift/deploy/job/etl-revert.yml
@@ -84,7 +84,7 @@ objects:
                 - bash
                 - -c
                 - |
-                  sqitch revert swrs/extract/table/ghgr_import -y;
+                  sqitch revert swrs/extract/table/eccc_xml_file -y;
           volumes:
             - name: ${PREFIX}ggircs-data
               persistentVolumeClaim:


### PR DESCRIPTION
This behavior will be updated soon