### PR TITLE
chore: update cas-postgres chart dependency to 0.5.0

### DIFF
--- a/helm/cas-ggircs/Chart.lock
+++ b/helm/cas-ggircs/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cas-postgres
   repository: https://bcgov.github.io/cas-postgres/
-  version: 0.4.0
-digest: sha256:dd246fbfdcecd3c442e20411c0d115d94f749bc07405f6281e5fb09e0f54d3be
-generated: "2020-06-11T15:05:50.15881217-07:00"
+  version: 0.5.0
+digest: sha256:386ce1a9e3272cee9d21b720f781f83177cc633134e04611c6092f31fc7c8532
+generated: "2020-07-06T08:47:01.534667805-07:00"

--- a/helm/cas-ggircs/Chart.yaml
+++ b/helm/cas-ggircs/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: cas-ggircs
 description: Helm chart for the GGIRCS database and ETL
 type: application
-version: 0.1.2
-appVersion: 1.0.0
+version: 0.1.3
+appVersion: 1.0.1
 dependencies:
 - name: cas-postgres
-  version: "0.4.0"
+  version: "0.5.0"
   repository: https://bcgov.github.io/cas-postgres/


### PR DESCRIPTION
This enables db health checks and graceful termination