### PR TITLE
Fix: ignore test reports on eccc load

### DIFF
--- a/deploy/private/prune_test_organisations_and_facilities.sql
+++ b/deploy/private/prune_test_organisations_and_facilities.sql
@@ -1,0 +1,18 @@
+-- Deploy ggircs:private/prune_test_organisations_and_facilities to pg
+
+begin;
+
+create or replace function swrs_private.prune_test_organisations_and_facilities()
+returns void as
+$function$
+  -- deleting the xml files first to satisfy foreign key constraints
+  delete from swrs_extract.eccc_xml_file where zip_file_id in
+    (select id from swrs_extract.eccc_zip_file where zip_file_name not like 'GHGBC_PROD_%');
+
+  -- deleting the zip files
+  delete from swrs_extract.eccc_zip_file where zip_file_name not like 'GHGBC_PROD_%';
+$function$ language sql;
+
+select swrs_private.prune_test_organisations_and_facilities();
+
+commit;

--- a/deploy/private/schema.sql
+++ b/deploy/private/schema.sql
@@ -1,0 +1,8 @@
+-- Deploy ggircs:private/schema to pg
+
+begin;
+
+create schema swrs_private;
+comment on schema swrs_private is 'A private schema containing the functions needed for the SWRS ETL';
+
+commit;

--- a/eccc/extract/app/extract_zips.py
+++ b/eccc/extract/app/extract_zips.py
@@ -39,6 +39,9 @@ def process_zip_file(bucket_name, file, pg_pool):
   if not file.name.endswith('.zip'):
     log.debug(f"{file.name} was uploaded in the bucket {bucket_name}, but that doesn't look like a zip file. Skipping.")
     return
+  if not file.name.startswith('GHGBC_PROD_'):
+    log.debug(f"{file.name} was uploaded in the bucket {bucket_name}, but that doesn't look like a production report. Skipping.")
+    return
   file_path = f"gs://{bucket_name}/{file.name}"
   zipfile_md5 = base64.b64decode(file.md5_hash).hex() if file.md5_hash is not None else None
   try:

--- a/helm/cas-ggircs/templates/etl/eccc-upload-cron.yaml
+++ b/helm/cas-ggircs/templates/etl/eccc-upload-cron.yaml
@@ -45,7 +45,7 @@ spec:
                 - name: DEPTH
                   value: "5"
                 - name: FILTER
-                  value: '\.zip|\.pp7m'
+                  value: 'GHGBC_PROD_.*(\.zip|\.pp7m)'
                 - name: GOOGLE_APPLICATION_CREDENTIALS
                   value: /app/gcs/credentials.json
               name: {{ template "cas-ggircs.fullname" . }}-eccc-upload

--- a/revert/private/prune_test_organisations_and_facilities.sql
+++ b/revert/private/prune_test_organisations_and_facilities.sql
@@ -1,0 +1,7 @@
+-- Revert ggircs:private/prune_test_organisations_and_facilities from pg
+
+begin;
+
+drop function swrs_private.prune_test_organisations_and_facilities;
+
+commit;

--- a/revert/private/schema.sql
+++ b/revert/private/schema.sql
@@ -1,0 +1,7 @@
+-- Revert ggircs:private/schema from pg
+
+begin;
+
+drop schema swrs_private;
+
+commit;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -109,3 +109,4 @@ swrs/public/table/facility_001 2021-04-26T17:06:22Z Matthieu Foucault <matthieu@
 swrs/transform/function/load_facility [swrs/transform/function/load_facility@v1.1.1] 2021-04-26T17:08:47Z Matthieu Foucault <matthieu@button.is> # add facility_bc_ghg_id to facility load function
 swrs/public/view/facility_details [swrs/public/view/facility_details@v1.1.1] 2021-04-26T19:29:00Z Matthieu Foucault <matthieu@button.is> # recreate facility_details view after adding a column to facility table
 private/schema 2021-04-26T21:44:59Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # A schema for private functions used by the SWRS ETL
+private/prune_test_organisations_and_facilities 2021-04-26T21:43:05Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # Private function that prunes all organisations and facilities imported from non-prod report files

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -108,3 +108,4 @@ swrs/transform/materialized_view/facility [swrs/transform/materialized_view/faci
 swrs/public/table/facility_001 2021-04-26T17:06:22Z Matthieu Foucault <matthieu@button.is> # add bg_ghg_id column to facility table
 swrs/transform/function/load_facility [swrs/transform/function/load_facility@v1.1.1] 2021-04-26T17:08:47Z Matthieu Foucault <matthieu@button.is> # add facility_bc_ghg_id to facility load function
 swrs/public/view/facility_details [swrs/public/view/facility_details@v1.1.1] 2021-04-26T19:29:00Z Matthieu Foucault <matthieu@button.is> # recreate facility_details view after adding a column to facility table
+private/schema 2021-04-26T21:44:59Z Pierre Bastianelli <pierre.bastianelli@gov.bc.ca> # A schema for private functions used by the SWRS ETL

--- a/test/style/schema_test.sql
+++ b/test/style/schema_test.sql
@@ -4,7 +4,7 @@ reset client_min_messages;
 
 begin;
 
-select plan(6);
+select plan(8);
 
 /** Check schema compliance **/
 

--- a/test/unit/prune_test_organisations_and_facilities_test.sql
+++ b/test/unit/prune_test_organisations_and_facilities_test.sql
@@ -1,0 +1,72 @@
+set client_min_messages to warning;
+create extension if not exists pgtap;
+reset client_min_messages;
+
+begin;
+select plan(5);
+
+select has_function('swrs_private', 'prune_test_organisations_and_facilities', 'Function prune_test_organisations_and_facilities should exist');
+
+delete from swrs_extract.eccc_zip_file;
+delete from swrs_extract.eccc_xml_file;
+
+insert into swrs_extract.eccc_zip_file(zip_file_name) values
+('GHGBC_PROD_00000000.zip'),
+('GHGBC_QC_00000000.zip'),
+('GHGBC_PROE_00000001.zip'),
+('BHGBC_PROD_00000002.zip'),
+('o9sa8f45789574ytfj2au727'),
+('GHGBC_PROD_99999999.zip');
+
+insert into swrs_extract.eccc_xml_file(xml_file, xml_file_name, zip_file_id) values
+('', 'test_xml_1', (select id from swrs_extract.eccc_zip_file where zip_file_name = 'GHGBC_PROD_00000000.zip')),
+('', 'test_xml_2', (select id from swrs_extract.eccc_zip_file where zip_file_name = 'GHGBC_PROD_00000000.zip')),
+('', 'test_xml_3', (select id from swrs_extract.eccc_zip_file where zip_file_name = 'GHGBC_QC_00000000.zip')),
+('', 'test_xml_4', (select id from swrs_extract.eccc_zip_file where zip_file_name = 'GHGBC_QC_00000000.zip')),
+('', 'test_xml_5', (select id from swrs_extract.eccc_zip_file where zip_file_name = 'GHGBC_QC_00000000.zip')),
+('', 'test_xml_6', (select id from swrs_extract.eccc_zip_file where zip_file_name = 'BHGBC_PROD_00000002.zip')),
+('', '2u94hsafdv89', (select id from swrs_extract.eccc_zip_file where zip_file_name = 'o9sa8f45789574ytfj2au727'));
+
+select results_eq(
+  $$
+    select count(*) from swrs_extract.eccc_zip_file
+  $$,
+  $$
+    values(6::bigint)
+  $$,
+  'There should be 6 test zip files'
+);
+select results_eq(
+  $$
+    select count(*) from swrs_extract.eccc_xml_file
+  $$,
+  $$
+    values(7::bigint)
+  $$,
+  'There should be 7 test xml files'
+);
+
+select swrs_private.prune_test_organisations_and_facilities();
+
+select results_eq(
+  $$
+    select zip_file_name from swrs_extract.eccc_zip_file
+  $$,
+  $$
+    values ('GHGBC_PROD_00000000.zip'::varchar), ('GHGBC_PROD_99999999.zip'::varchar)
+  $$,
+  'prune_test_organisations_and_facilities doesnt remove prod zip files'
+);
+
+select results_eq(
+  $$
+    select xml_file_name from swrs_extract.eccc_xml_file
+  $$,
+  $$
+    values ('test_xml_1'::varchar), ('test_xml_2'::varchar)
+  $$,
+  'prune_test_organisations_and_facilities only removes the xml in the non-prod zip files'
+);
+
+select finish();
+rollback;

--- a/verify/private/prune_test_organisations_and_facilities.sql
+++ b/verify/private/prune_test_organisations_and_facilities.sql
@@ -1,0 +1,7 @@
+-- Verify ggircs:private/prune_test_organisations_and_facilities on pg
+
+begin;
+
+select pg_get_functiondef('swrs_private.prune_test_organisations_and_facilities()'::regprocedure);
+
+rollback;

--- a/verify/private/schema.sql
+++ b/verify/private/schema.sql
@@ -1,0 +1,7 @@
+-- Verify ggircs:private/schema on pg
+
+begin;
+
+select pg_catalog.has_schema_privilege('swrs_private', 'usage');
+
+rollback;


### PR DESCRIPTION
Preventing Test / Quality Control reports from being downloaded from ECCC, and uploaded to GCP

- [x] filter regex on file download
- [x] verify that filename starts with GHGBC_PROD_ before upload
- [x] migration that prunes existing QC zip files and reports
