### PR TITLE
Fix: increase varchar limit for update_comment

### DIFF
--- a/deploy/swrs/public/table/report_001.sql
+++ b/deploy/swrs/public/table/report_001.sql
@@ -1,0 +1,8 @@
+-- Deploy ggircs:swrs/public/table/report_001 to pg
+-- requires: swrs/public/table/report
+
+begin;
+
+alter table swrs.report alter column update_comment type varchar (100000);
+
+commit;

--- a/deploy/swrs/transform/materialized_view/report_001.sql
+++ b/deploy/swrs/transform/materialized_view/report_001.sql
@@ -1,0 +1,13 @@
+-- Deploy ggircs:swrs/transform/materialized_view/report_001 to pg
+-- requires: swrs/transform/materialized_view/report
+
+begin;
+
+-- Changes varchar size of swrs_transform.update_comment to 100000
+-- Cannot drop materialized view as other items depend on it, alter materialized view does not support changing datatypes
+-- https://stackoverflow.com/questions/7729287/postgresql-change-the-size-of-a-varchar-column-to-lower-length
+update pg_attribute set atttypmod = 100000+4
+where attrelid = 'swrs_transform.report'::regclass
+and attname = 'update_comment';
+
+commit;

--- a/ggircs-app/app/package.json
+++ b/ggircs-app/app/package.json
@@ -38,7 +38,7 @@
     "isomorphic-fetch": "^3.0.0",
     "keycloak-connect": "^12.0.1",
     "morgan": "^1.10.0",
-    "next": "10.2.0",
+    "next": "10.2.3",
     "pg": "^8.5.1",
     "postgraphile": "^4.10.0",
     "postgraphile-log-consola": "^1.0.1",

--- a/ggircs-app/app/yarn.lock
+++ b/ggircs-app/app/yarn.lock
@@ -877,10 +877,10 @@
   dependencies:
     tslib "^2.0.1"
 
-"@hapi/accept@5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@hapi/accept/-/accept-5.0.1.tgz#068553e867f0f63225a506ed74e899441af53e10"
-  integrity sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==
+"@hapi/accept@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@hapi/accept/-/accept-5.0.2.tgz#ab7043b037e68b722f93f376afb05e85c0699523"
+  integrity sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==
   dependencies:
     "@hapi/boom" "9.x.x"
     "@hapi/hoek" "9.x.x"
@@ -1127,20 +1127,20 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@next/env@10.2.0":
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-10.2.0.tgz#154dbce2efa3ad067ebd20b7d0aa9aed775e7c97"
-  integrity sha512-tsWBsn1Rb6hXRaHc/pWMCpZ4Ipkf3OCbZ54ef5ukgIyEvzzGdGFXQshPP2AF7yb+8yMpunWs7vOMZW3e8oPF6A==
+"@next/env@10.2.3":
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-10.2.3.tgz#ede3bbe68cec9939c37168ea2077f9adbc68334e"
+  integrity sha512-uBOjRBjsWC4C8X3DfmWWP6ekwLnf2JCCwQX9KVnJtJkqfDsv1yQPakdOEwvJzXQc3JC/v5KKffYPVmV2wHXCgQ==
 
-"@next/polyfill-module@10.2.0":
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-10.2.0.tgz#61f41110c4b465cc26d113e2054e205df61c3594"
-  integrity sha512-Nl3GexIUXsmuggkUqrRFyE/2k7UI44JaVzSywtXEyHzxpZm2a5bdMaWuC89pgLiFDDOqmbqyLAbtwm5lNxa7Eg==
+"@next/polyfill-module@10.2.3":
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-10.2.3.tgz#5a29f50c3ce3a56b8268d3b8331c691d8039467a"
+  integrity sha512-OkeY4cLhzfYbXxM4fd+6V4s5pTPuyfKSlavItfNRA6PpS7t1/R6YjO7S7rB8tu1pbTGuDHGIdE1ioDv15bAbDQ==
 
-"@next/react-dev-overlay@10.2.0":
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-10.2.0.tgz#4220121abac7e3404cbaf467784aeecca8be46cf"
-  integrity sha512-PRIAoWog41hLN4iJ8dChKp4ysOX0Q8yiNQ/cwzyqEd3EjugkDV5OiKl3mumGKaApJaIra1MX6j1wgQRuLhuWMA==
+"@next/react-dev-overlay@10.2.3":
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-10.2.3.tgz#95313d10a8848f6c7b9e31ae3bd2a3627d136841"
+  integrity sha512-E6g2jws4YW94l0lMMopBVKIZK2mEHfSBvM0d9dmzKG9L/A/kEq6LZCB4SiwGJbNsAdlk2y3USDa0oNbpA+m5Kw==
   dependencies:
     "@babel/code-frame" "7.12.11"
     anser "1.4.9"
@@ -1154,10 +1154,10 @@
     stacktrace-parser "0.1.10"
     strip-ansi "6.0.0"
 
-"@next/react-refresh-utils@10.2.0":
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-10.2.0.tgz#55953b697769c6647f371bc6bcd865a24e1a22e9"
-  integrity sha512-3I31K9B4hEQRl7yQ44Umyz+szHtuMJrNdwsgJGhoEnUCXSBRHp5wv5Zv8eDa2NewSbe53b2C0oOpivrzmdBakw==
+"@next/react-refresh-utils@10.2.3":
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-10.2.3.tgz#2f3e42fe6680798f276e3621345c2886b231348b"
+  integrity sha512-qtBF56vPC6d6a8p7LYd0iRjW89fhY80kAIzmj+VonvIGjK/nymBjcFUhbKiMFqlhsarCksnhwX+Zmn95Dw9qvA==
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
@@ -2471,16 +2471,16 @@ browserify-zlib@0.2.0, browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@4.16.1:
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.1.tgz#bf757a2da376b3447b800a16f0f1c96358138766"
-  integrity sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==
+browserslist@4.16.6:
+  version "4.16.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
+  integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
   dependencies:
-    caniuse-lite "^1.0.30001173"
-    colorette "^1.2.1"
-    electron-to-chromium "^1.3.634"
+    caniuse-lite "^1.0.30001219"
+    colorette "^1.2.2"
+    electron-to-chromium "^1.3.723"
     escalade "^3.1.1"
-    node-releases "^1.1.69"
+    node-releases "^1.1.71"
 
 bser@2.1.1:
   version "2.1.1"
@@ -2611,10 +2611,15 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001202:
+caniuse-lite@^1.0.30001202:
   version "1.0.30001228"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz#bfdc5942cd3326fa51ee0b42fbef4da9d492a7fa"
   integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
+
+caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228:
+  version "1.0.30001232"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001232.tgz#2ebc8b6a77656fd772ab44a82a332a26a17e9527"
+  integrity sha512-e4Gyp7P8vqC2qV2iHA+cJNf/yqUKOShXQOJHQt81OHxlIZl/j/j3soEA0adAQi8CPUQgvOdDENyQ5kd6a6mNSg==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -2858,7 +2863,7 @@ color-name@^1.1.4, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^1.2.1, colorette@^1.2.2:
+colorette@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
@@ -3585,10 +3590,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.634:
-  version "1.3.727"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz#857e310ca00f0b75da4e1db6ff0e073cc4a91ddf"
-  integrity sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg==
+electron-to-chromium@^1.3.723:
+  version "1.3.742"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.742.tgz#7223215acbbd3a5284962ebcb6df85d88b95f200"
+  integrity sha512-ihL14knI9FikJmH2XUIDdZFWJxvr14rPSdOhJ7PpS27xbz8qmaRwCwyg/bmFwjWKmWK9QyamiCZVCvXm5CH//Q==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -6887,24 +6892,24 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-next@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/next/-/next-10.2.0.tgz#6654cc925d8abcb15474fa062fc6b3ee527dd6dc"
-  integrity sha512-PKDKCSF7s82xudu3kQhOEaokxggpbLEWouEUtzP6OqV0YqKYHF+Ff+BFLycEem8ixtTM2M6ElN0VRJcskJfxPQ==
+next@10.2.3:
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/next/-/next-10.2.3.tgz#5aa058a63626338cea91c198fda8f2715c058394"
+  integrity sha512-dkM1mIfnORtGyzw/Yme8RdqNxlCMZyi4Lqj56F01/yHbe1ZtOaJ0cyqqRB4RGiPhjGGh0319f8ddjDyO1605Ow==
   dependencies:
     "@babel/runtime" "7.12.5"
-    "@hapi/accept" "5.0.1"
-    "@next/env" "10.2.0"
-    "@next/polyfill-module" "10.2.0"
-    "@next/react-dev-overlay" "10.2.0"
-    "@next/react-refresh-utils" "10.2.0"
+    "@hapi/accept" "5.0.2"
+    "@next/env" "10.2.3"
+    "@next/polyfill-module" "10.2.3"
+    "@next/react-dev-overlay" "10.2.3"
+    "@next/react-refresh-utils" "10.2.3"
     "@opentelemetry/api" "0.14.0"
     assert "2.0.0"
     ast-types "0.13.2"
     browserify-zlib "0.2.0"
-    browserslist "4.16.1"
+    browserslist "4.16.6"
     buffer "5.6.0"
-    caniuse-lite "^1.0.30001179"
+    caniuse-lite "^1.0.30001228"
     chalk "2.4.2"
     chokidar "3.5.1"
     constants-browserify "1.0.0"
@@ -7021,10 +7026,10 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-releases@^1.1.69:
-  version "1.1.71"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
-  integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
+node-releases@^1.1.71:
+  version "1.1.72"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.72.tgz#14802ab6b1039a79a0c7d662b610a5bbd76eacbe"
+  integrity sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"

--- a/revert/swrs/public/table/report_001.sql
+++ b/revert/swrs/public/table/report_001.sql
@@ -1,0 +1,7 @@
+-- Revert ggircs:swrs/public/table/report_001 from pg
+
+begin;
+
+alter table swrs.report alter column update_comment type varchar (1000);
+
+commit;

--- a/revert/swrs/transform/materialized_view/report_001.sql
+++ b/revert/swrs/transform/materialized_view/report_001.sql
@@ -1,0 +1,9 @@
+-- Revert ggircs:swrs/transform/materialized_view/report_001 from pg
+
+begin;
+
+update pg_attribute set atttypmod = 1000+4
+where attrelid = 'swrs_transform.report'::regclass
+and attname = 'update_comment';
+
+commit;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -117,3 +117,4 @@ swrs/public/table/fuel_charge_003 [swrs/public/table/fuel_charge_002] 2021-05-04
 swrs/public/table/fuel_carbon_tax_details_002 [swrs/public/table/fuel_carbon_tax_details_001] 2021-05-04T16:22:07Z Dylan Leard <dylan@button.is> # Migration: drop unused carbon_taxed column
 swrs/add_missing_indices 2021-05-05T17:10:13Z Dylan Leard <dylan@button.is> # Add an index to all foreign keys that are currently missing one
 swrs/public/table/report_001 [swrs/public/table/report] 2021-05-31T20:23:04Z Dylan Leard <dylan@button.is> # Migration: increase varchar size of update_comment column
+swrs/transform/materialized_view/report_001 [swrs/transform/materialized_view/report] 2021-05-31T20:26:56Z Dylan Leard <dylan@button.is> # Migration: increase varchar size limit on update_comment column

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -116,3 +116,4 @@ swrs/transform/function/load_fuel_carbon_tax_details [swrs/transform/function/lo
 swrs/public/table/fuel_charge_003 [swrs/public/table/fuel_charge_002] 2021-05-04T16:13:19Z Dylan Leard <dylan@button.is> # Migration: remove deprecated foreign key columns
 swrs/public/table/fuel_carbon_tax_details_002 [swrs/public/table/fuel_carbon_tax_details_001] 2021-05-04T16:22:07Z Dylan Leard <dylan@button.is> # Migration: drop unused carbon_taxed column
 swrs/add_missing_indices 2021-05-05T17:10:13Z Dylan Leard <dylan@button.is> # Add an index to all foreign keys that are currently missing one
+swrs/public/table/report_001 [swrs/public/table/report] 2021-05-31T20:23:04Z Dylan Leard <dylan@button.is> # Migration: increase varchar size of update_comment column

--- a/test/unit/materialized_view_report_test.sql
+++ b/test/unit/materialized_view_report_test.sql
@@ -43,7 +43,7 @@ select col_type_is('swrs_transform', 'report', 'status', 'character varying(1000
 select col_type_is('swrs_transform', 'report', 'version', 'character varying(1000)', 'Matview report column version has type character varying(1000)');
 select col_type_is('swrs_transform', 'report', 'submission_date', 'timestamp with time zone', 'Matview report column submission_date has type character varying(1000)');
 select col_type_is('swrs_transform', 'report', 'last_modified_by', 'character varying(1000)', 'Matview report column last_modified_by has type character varying(1000)');
-select col_type_is('swrs_transform', 'report', 'update_comment', 'character varying(1000)', 'Matview report column update_comment has type character varying(1000)');
+select col_type_is('swrs_transform', 'report', 'update_comment', 'character varying(100000)', 'Matview report column update_comment has type character varying(100000)');
 
 -- Setup fixture
 insert into swrs_extract.eccc_xml_file (imported_at, xml_file) VALUES ('2018-09-29T11:55:39.423', $$

--- a/verify/swrs/public/table/report_001.sql
+++ b/verify/swrs/public/table/report_001.sql
@@ -1,0 +1,7 @@
+-- Verify ggircs:swrs/public/table/report_001 on pg
+
+begin;
+
+select pg_catalog.has_table_privilege('swrs.report', 'select');
+
+rollback;

--- a/verify/swrs/transform/materialized_view/report_001.sql
+++ b/verify/swrs/transform/materialized_view/report_001.sql
@@ -1,0 +1,10 @@
+-- Verify ggircs:swrs/transform/materialized_view/report_001 on pg
+
+begin;
+
+-- selecting from the matview will throw an error if it doesn't exist
+-- but there's no need to return any value so select where false
+select * from swrs_transform.report where false;
+--  select false from pg_matviews where schemaname = 'swrs_transform' and matviewname = 'report';
+
+rollback;


### PR DESCRIPTION
ETL failed due to an `update_comment` larger than the allotted varchar size for swrs.report / swrs_transform.report.
This PR increases the size limit for update_comment in both the table and materialized view.