### PR TITLE
fix: revert bad migration & fix update_comment datatype

### DIFF
--- a/deploy/swrs/transform/materialized_view/report_001.sql
+++ b/deploy/swrs/transform/materialized_view/report_001.sql
@@ -3,11 +3,95 @@
 
 begin;
 
--- Changes varchar size of swrs_transform.update_comment to 100000
--- Cannot drop materialized view as other items depend on it, alter materialized view does not support changing datatypes
--- https://stackoverflow.com/questions/7729287/postgresql-change-the-size-of-a-varchar-column-to-lower-length
-update pg_attribute set atttypmod = 100000+4
-where attrelid = 'swrs_transform.report'::regclass
-and attname = 'update_comment';
+-- drop cascades to swrs_transform.final_report
+drop materialized view swrs_transform.report cascade;
+
+create materialized view swrs_transform.report as (
+  select
+    row_number() over () as id,
+    id as eccc_xml_file_id,
+    xml_file as source_xml,
+    imported_at,
+    report_details.swrs_report_id,
+    report_details.prepop_report_id,
+    report_details.report_type,
+    report_details.swrs_facility_id,
+    report_details.swrs_organisation_id,
+    (regexp_matches(report_details.reporting_period_duration::varchar(1000), '\d\d\d\d'))[1]::integer as reporting_period_duration,
+    report_status.*
+  from swrs_extract.eccc_xml_file,
+       xmltable(
+           '/ReportData/ReportDetails'
+           passing xml_file
+           columns
+             swrs_report_id integer path 'ReportID[normalize-space(.)]' not null,
+             prepop_report_id integer path 'PrepopReportID[normalize-space(.)]',
+             report_type varchar(1000) path 'ReportType[normalize-space(.)]' not null,
+             swrs_facility_id integer path 'FacilityId[normalize-space(.)]' not null,
+             swrs_organisation_id integer path 'OrganisationId[normalize-space(.)]' not null,
+             reporting_period_duration integer path 'ReportingPeriodDuration[normalize-space(.)]' not null
+         ) as report_details,
+
+       xmltable(
+           '/ReportData/ReportDetails/ReportStatus'
+           passing xml_file
+           columns
+             status varchar(1000) path 'Status|ReportStatus[normalize-space(.)]' not null, -- Unknown, In Progress, Submitted, Archived, Completed
+             version varchar(1000) path 'Version[normalize-space(.)]',
+             submission_date timestamptz path 'SubmissionDate[normalize-space(.)]',
+             last_modified_by varchar(1000) path 'LastModifiedBy[normalize-space(.)]' not null,
+             last_modified_date timestamp with time zone path 'LastModifiedDate[normalize-space(.)]',
+             update_comment varchar(100000) path 'UpdateComment[normalize-space(.)]'
+         ) as report_status
+) with no data;
+
+create unique index ggircs_report_primary_key on swrs_transform.report (eccc_xml_file_id);
+
+comment on materialized view swrs_transform.report is 'The materialized view housing all report data, derived from eccc_xml_file table';
+comment on column swrs_transform.report.id is 'A generated index used for keying in the ggircs schema';
+comment on column swrs_transform.report.eccc_xml_file_id is 'The internal primary key for the file';
+comment on column swrs_transform.report.source_xml is 'The raw xml file imported from GHGR';
+comment on column swrs_transform.report.imported_at is 'The timestamp noting when the file was imported';
+comment on column swrs_transform.report.swrs_report_id is 'The swrs report id';
+comment on column swrs_transform.report.prepop_report_id is 'The prepop report id';
+comment on column swrs_transform.report.report_type is 'The type of report';
+comment on column swrs_transform.report.swrs_facility_id is 'The ID for the reporting facility';
+comment on column swrs_transform.report.swrs_organisation_id is 'The ID for the reporting organisation';
+comment on column swrs_transform.report.reporting_period_duration is 'The length of the reporting period contained in report';
+comment on column swrs_transform.report.status is 'The status of the report';
+comment on column swrs_transform.report.version is 'The report version';
+comment on column swrs_transform.report.submission_date is 'The date the report was submitted';
+comment on column swrs_transform.report.last_modified_by is 'The person who last modified the report';
+comment on column swrs_transform.report.last_modified_date is 'The timestamp recorded in SWRS when the report was last modified';
+comment on column swrs_transform.report.update_comment is 'The description of the update';
+
+create view swrs_transform.final_report as (
+    with _report as (
+    select *,
+           row_number() over (
+             partition by swrs_facility_id, reporting_period_duration
+             order by
+               swrs_report_id desc,
+               submission_date desc,
+               imported_at desc
+               ) as _history_id
+    from swrs_transform.report
+    where submission_date is not null
+      and report_type != 'SaleClosePurchase'
+    and eccc_xml_file_id not in (select report.eccc_xml_file_id
+                       from swrs_transform.ignore_organisation
+                       join swrs_transform.report on ignore_organisation.swrs_organisation_id = report.swrs_organisation_id)
+    order by swrs_report_id
+  )
+  select row_number() over () as id, swrs_report_id, eccc_xml_file_id
+  from _report
+  where _history_id = 1
+  order by swrs_report_id asc
+);
+
+comment on view swrs_transform.final_report is 'The view showing the latest submitted report by swrs_transform.report.id';
+comment on column swrs_transform.final_report.id is 'A generated index used for keying in the swrs schema';
+comment on column swrs_transform.final_report.swrs_report_id is 'The foreign key referencing swrs_transform.report.id';
+comment on column swrs_transform.final_report.eccc_xml_file_id is 'The foreign key referencing swrs_extract.eccc_xml_file.id';
 
 commit;

--- a/deploy/swrs/transform/materialized_view/report_001@v1.3.0.sql
+++ b/deploy/swrs/transform/materialized_view/report_001@v1.3.0.sql
@@ -1,0 +1,13 @@
+-- Deploy ggircs:swrs/transform/materialized_view/report_001 to pg
+-- requires: swrs/transform/materialized_view/report
+
+begin;
+
+-- Changes varchar size of swrs_transform.update_comment to 100000
+-- Cannot drop materialized view as other items depend on it, alter materialized view does not support changing datatypes
+-- https://stackoverflow.com/questions/7729287/postgresql-change-the-size-of-a-varchar-column-to-lower-length
+update pg_attribute set atttypmod = 100000+4
+where attrelid = 'swrs_transform.report'::regclass
+and attname = 'update_comment';
+
+commit;

--- a/revert/swrs/transform/materialized_view/report_001.sql
+++ b/revert/swrs/transform/materialized_view/report_001.sql
@@ -1,9 +1,8 @@
--- Revert ggircs:swrs/transform/materialized_view/report_001 from pg
+-- Deploy ggircs:swrs/transform/materialized_view/report_001 to pg
+-- requires: swrs/transform/materialized_view/report
 
 begin;
 
-update pg_attribute set atttypmod = 1000+4
-where attrelid = 'swrs_transform.report'::regclass
-and attname = 'update_comment';
+-- No revert required
 
 commit;

--- a/revert/swrs/transform/materialized_view/report_001@v1.3.0.sql
+++ b/revert/swrs/transform/materialized_view/report_001@v1.3.0.sql
@@ -1,0 +1,7 @@
+-- Revert ggircs:swrs/transform/materialized_view/report_001 from pg
+
+begin;
+
+-- No revert required
+
+commit;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -119,3 +119,4 @@ swrs/add_missing_indices 2021-05-05T17:10:13Z Dylan Leard <dylan@button.is> # Ad
 swrs/public/table/report_001 [swrs/public/table/report] 2021-05-31T20:23:04Z Dylan Leard <dylan@button.is> # Migration: increase varchar size of update_comment column
 swrs/transform/materialized_view/report_001 [swrs/transform/materialized_view/report] 2021-05-31T20:26:56Z Dylan Leard <dylan@button.is> # Migration: increase varchar size limit on update_comment column
 @v1.3.0 2021-05-31T22:07:23Z Dylan Leard <dylan@button.is> # release v1.3.0
+swrs/transform/materialized_view/report_001 [swrs/transform/materialized_view/report_001@v1.3.0] 2021-06-01T17:49:49Z Dylan Leard <dylan@button.is> # Migration: deploy user cannot change pg_attribute table. Drop materialized view cascade & recreate dropped entities instead.

--- a/verify/swrs/transform/materialized_view/report_001@v1.3.0.sql
+++ b/verify/swrs/transform/materialized_view/report_001@v1.3.0.sql
@@ -1,0 +1,10 @@
+-- Verify ggircs:swrs/transform/materialized_view/report_001 on pg
+
+begin;
+
+-- selecting from the matview will throw an error if it doesn't exist
+-- but there's no need to return any value so select where false
+select * from swrs_transform.report where false;
+--  select false from pg_matviews where schemaname = 'swrs_transform' and matviewname = 'report';
+
+rollback;


### PR DESCRIPTION
- The migration in https://github.com/bcgov/cas-ggircs/pull/252 cannot be done by our deploy user (and is probably bad practice to edit this table anyway)
- This PR reverts that migration & fixes the update_comment datatype issue with a drop cascade & recreates the dropped items.