### PR TITLE
chore: CVEs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 postgres 12.6
-nodejs 14.15.4
+nodejs 14.17.2
 yarn 1.22.10
 python 3.7.0


### PR DESCRIPTION
Deploying this will should pull the latest `debian:10` image, which has additional security fixes