### PR TITLE
Fix: diff broken after relay 13 upgrade

### DIFF
--- a/ggircs-app/app/.eslintrc.js
+++ b/ggircs-app/app/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
   },
   rules: {
     "@typescript-eslint/no-shadow": 1,
-    "react-hooks/rules-of-hooks": "error",
     // "react/prop-types": 0, // don't need react/prop-types when components are typed with typescript
     // "react/state-in-constructor": [1, "never"],
     "@typescript-eslint/no-unused-expressions": [1, { allowTernary: true }],

--- a/ggircs-app/app/.eslintrc.js
+++ b/ggircs-app/app/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   rules: {
     "@typescript-eslint/no-shadow": 1,
-    "react-hooks/rules-of-hooks": 1,
+    "react-hooks/rules-of-hooks": "error",
     // "react/prop-types": 0, // don't need react/prop-types when components are typed with typescript
     // "react/state-in-constructor": [1, "never"],
     "@typescript-eslint/no-unused-expressions": [1, { allowTernary: true }],

--- a/ggircs-app/app/components/XmlDiff/RenderDiff.tsx
+++ b/ggircs-app/app/components/XmlDiff/RenderDiff.tsx
@@ -54,22 +54,19 @@ const RenderDiff: React.FC<Props> = ({ query }) => {
     query
   );
 
-  const shouldRenderDiff =
-    firstSideReport &&
-    secondSideReport &&
-    router.query.FirstSideRelayId &&
-    router.query.SecondSideRelayId;
-  if (!shouldRenderDiff) return null;
-
   const [isLoading, setIsLoading] = useState(true);
   const [diffText, setDiffText] = useState(null);
 
-  const oldText = format(
-    firstSideReport.latestSwrsReport.ecccXmlFileByEcccXmlFileId.xmlFile
-  );
-  const newText = format(
-    secondSideReport.latestSwrsReport.ecccXmlFileByEcccXmlFileId.xmlFile
-  );
+  const oldText = firstSideReport
+    ? format(
+        firstSideReport.latestSwrsReport.ecccXmlFileByEcccXmlFileId.xmlFile
+      )
+    : "";
+  const newText = secondSideReport
+    ? format(
+        secondSideReport.latestSwrsReport.ecccXmlFileByEcccXmlFileId.xmlFile
+      )
+    : "";
 
   useEffect(() => {
     setIsLoading(false);
@@ -90,7 +87,14 @@ const RenderDiff: React.FC<Props> = ({ query }) => {
           context: router.query.collapsed ? 1 : 10000,
         })
       );
-  }, [router.query]);
+  }, [router.query, newText, oldText]);
+
+  const shouldRenderDiff =
+    firstSideReport &&
+    secondSideReport &&
+    router.query.FirstSideRelayId &&
+    router.query.SecondSideRelayId;
+  if (!shouldRenderDiff) return null;
 
   if (isLoading) return <LoadingSpinner />;
 

--- a/ggircs-app/app/components/XmlDiff/ReportSelector.tsx
+++ b/ggircs-app/app/components/XmlDiff/ReportSelector.tsx
@@ -9,11 +9,15 @@ import { useRouter } from "next/router";
 interface Props {
   diffSide: String;
   allReports: readonly RelayReportObject[];
+  onUserTyping: (isUserTyping: boolean) => void;
+  disabled: boolean;
 }
 
 export const ReportSelector: React.FunctionComponent<Props> = ({
   diffSide,
   allReports,
+  onUserTyping,
+  disabled,
 }) => {
   const router = useRouter();
 
@@ -61,13 +65,17 @@ export const ReportSelector: React.FunctionComponent<Props> = ({
   };
 
   const debouncedToRouter = useCallback(
-    debounce((nextValue) => validateReportId(Number(nextValue)), 1000),
+    debounce((nextValue) => {
+      onUserTyping(false);
+      validateReportId(Number(nextValue));
+    }, 1000),
     [router]
   );
 
   const handleChange = (event) => {
     const { value: nextValue } = event.target;
     setSwrsReportId(nextValue);
+    onUserTyping(true);
     debouncedToRouter(nextValue);
   };
 
@@ -82,6 +90,7 @@ export const ReportSelector: React.FunctionComponent<Props> = ({
       size="medium"
       onChange={handleChange}
       value={String(swrsReportId)}
+      disabled={disabled}
     />
   );
 

--- a/ggircs-app/app/components/XmlDiff/ReportSelector.tsx
+++ b/ggircs-app/app/components/XmlDiff/ReportSelector.tsx
@@ -1,50 +1,47 @@
-import { useState, useCallback } from "react";
+import { useState } from "react";
 import { RelayReportObject } from "types";
 import Input from "@button-inc/bcgov-theme/Input";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheck, faTimes } from "@fortawesome/free-solid-svg-icons";
 import debounce from "lodash.debounce";
-import { useRouter } from "next/router";
+import { NextRouter } from "next/router";
 
 interface Props {
   diffSide: String;
   allReports: readonly RelayReportObject[];
+  router: NextRouter;
 }
 
 export const ReportSelector: React.FunctionComponent<Props> = ({
   diffSide,
   allReports,
+  router,
 }) => {
-  const router = useRouter();
-
   const [swrsReportIdIsValid, setSwrsReportIdIsvalid] = useState<boolean>(null);
   const [swrsReportId, setSwrsReportId] = useState<number>(
     Number(router.query[`${diffSide}SideId`])
   );
 
-  const handleRouter = useCallback(
-    (id: number, relayId: string, valid: boolean) => {
-      let query;
-      if (valid) {
-        query = {
-          ...router.query,
-          [`${diffSide}SideId`]: id,
-          [`${diffSide}SideRelayId`]: relayId,
-        };
-      } else {
-        query = router.query;
-        delete query[`${diffSide}SideId`];
-        delete query[`${diffSide}SideRelayId`];
-      }
-      if (!relayId) delete query[`${diffSide}SideRelayId`];
-      const url = {
-        pathname: router.pathname,
-        query,
+  const handleRouter = (id: number, relayId: string, valid: boolean) => {
+    let query;
+    if (valid) {
+      query = {
+        ...router.query,
+        [`${diffSide}SideId`]: id,
+        [`${diffSide}SideRelayId`]: relayId,
       };
-      router.push(url, url, { shallow: true });
-    },
-    [router, diffSide]
-  );
+    } else {
+      query = router.query;
+      delete query[`${diffSide}SideId`];
+      delete query[`${diffSide}SideRelayId`];
+    }
+    if (!relayId) delete query[`${diffSide}SideRelayId`];
+    const url = {
+      pathname: router.pathname,
+      query,
+    };
+    router.push(url, url, { shallow: true });
+  };
 
   const validateReportId = (id: number) => {
     const edge = allReports.find((edge) => edge?.node.swrsReportId === id);
@@ -60,9 +57,9 @@ export const ReportSelector: React.FunctionComponent<Props> = ({
     }
   };
 
-  const debouncedToRouter = useCallback(
-    debounce((nextValue) => validateReportId(Number(nextValue)), 1000),
-    []
+  const debouncedToRouter = debounce(
+    (nextValue) => validateReportId(Number(nextValue)),
+    1000
   );
 
   const handleChange = (event) => {

--- a/ggircs-app/app/package.json
+++ b/ggircs-app/app/package.json
@@ -56,7 +56,7 @@
     "postgraphile-plugin-connection-filter": "^2.2.2",
     "react": "^17.0.2",
     "react-bootstrap": "^2.1.1",
-    "react-diff-view": "^2.4.8",
+    "react-diff-view": "^2.4.10",
     "react-dom": "^17.0.2",
     "react-relay": "^13.0.1",
     "react-relay-network-modern": "^6.2.1",

--- a/ggircs-app/app/pages/ggircs/xml-diff.tsx
+++ b/ggircs-app/app/pages/ggircs/xml-diff.tsx
@@ -46,8 +46,6 @@ export function XmlDiff({ preloadedQuery }: RelayProps<{}, xmlDiffQuery>) {
   const [firstSelectorEditing, setFirstSelectorEditing] = useState(false);
   const [secondSelectorEditing, setSecondSelectorEditing] = useState(false);
 
-  // We need to ensure both ReportSelector components share the same router, otherwise they
-  // can't write on the same query in the URL.
   const router = useRouter();
 
   return (

--- a/ggircs-app/app/pages/ggircs/xml-diff.tsx
+++ b/ggircs-app/app/pages/ggircs/xml-diff.tsx
@@ -8,9 +8,8 @@ import ReportSelector from "components/XmlDiff/ReportSelector";
 import DiffDetailsContainer from "components/XmlDiff/DiffDetailsContainer";
 import RenderDiff from "components/XmlDiff/RenderDiff";
 import DiffControls from "components/XmlDiff/DiffControls";
-import { useRouter } from "next/router";
+import { useRouter, NextRouter } from "next/router";
 import type { NextPageContext } from "next";
-import { NextRouter } from "next/router";
 
 export const XmlDiffQuery = graphql`
   query xmlDiffQuery($FirstSideRelayId: ID!, $SecondSideRelayId: ID!) {

--- a/ggircs-app/app/pages/ggircs/xml-diff.tsx
+++ b/ggircs-app/app/pages/ggircs/xml-diff.tsx
@@ -42,6 +42,9 @@ export const XmlDiffQuery = graphql`
 
 export function XmlDiff({ preloadedQuery }: RelayProps<{}, xmlDiffQuery>) {
   const { query } = usePreloadedQuery(XmlDiffQuery, preloadedQuery);
+
+  // We need to ensure both ReportSelector components share the same router, otherwise they
+  // can't write on the same query in the URL.
   const router = useRouter();
 
   return (
@@ -55,12 +58,14 @@ export function XmlDiff({ preloadedQuery }: RelayProps<{}, xmlDiffQuery>) {
           <ReportSelector
             diffSide={router.query.reversed ? "Second" : "First"}
             allReports={query.allReports.edges}
+            router={router}
           />
         </Col>
         <Col md={{ span: 6, order: router.query.reversed ? 1 : 2 }}>
           <ReportSelector
             diffSide={router.query.reversed ? "First" : "Second"}
             allReports={query.allReports.edges}
+            router={router}
           />
         </Col>
       </Row>

--- a/ggircs-app/app/pages/ggircs/xml-diff.tsx
+++ b/ggircs-app/app/pages/ggircs/xml-diff.tsx
@@ -57,14 +57,12 @@ export function XmlDiff({ preloadedQuery }: RelayProps<{}, xmlDiffQuery>) {
           <ReportSelector
             diffSide={router.query.reversed ? "Second" : "First"}
             allReports={query.allReports.edges}
-            router={router}
           />
         </Col>
         <Col md={{ span: 6, order: router.query.reversed ? 1 : 2 }}>
           <ReportSelector
             diffSide={router.query.reversed ? "First" : "Second"}
             allReports={query.allReports.edges}
-            router={router}
           />
         </Col>
       </Row>

--- a/ggircs-app/app/pages/ggircs/xml-diff.tsx
+++ b/ggircs-app/app/pages/ggircs/xml-diff.tsx
@@ -10,6 +10,7 @@ import RenderDiff from "components/XmlDiff/RenderDiff";
 import DiffControls from "components/XmlDiff/DiffControls";
 import { useRouter, NextRouter } from "next/router";
 import type { NextPageContext } from "next";
+import { useState } from "react";
 
 export const XmlDiffQuery = graphql`
   query xmlDiffQuery($FirstSideRelayId: ID!, $SecondSideRelayId: ID!) {
@@ -42,6 +43,9 @@ export const XmlDiffQuery = graphql`
 export function XmlDiff({ preloadedQuery }: RelayProps<{}, xmlDiffQuery>) {
   const { query } = usePreloadedQuery(XmlDiffQuery, preloadedQuery);
 
+  const [firstSelectorEditing, setFirstSelectorEditing] = useState(false);
+  const [secondSelectorEditing, setSecondSelectorEditing] = useState(false);
+
   // We need to ensure both ReportSelector components share the same router, otherwise they
   // can't write on the same query in the URL.
   const router = useRouter();
@@ -57,12 +61,20 @@ export function XmlDiff({ preloadedQuery }: RelayProps<{}, xmlDiffQuery>) {
           <ReportSelector
             diffSide={router.query.reversed ? "Second" : "First"}
             allReports={query.allReports.edges}
+            onUserTyping={(isUserTyping) =>
+              setFirstSelectorEditing(isUserTyping)
+            }
+            disabled={secondSelectorEditing}
           />
         </Col>
         <Col md={{ span: 6, order: router.query.reversed ? 1 : 2 }}>
           <ReportSelector
             diffSide={router.query.reversed ? "First" : "Second"}
             allReports={query.allReports.edges}
+            onUserTyping={(isUserTyping) =>
+              setSecondSelectorEditing(isUserTyping)
+            }
+            disabled={firstSelectorEditing}
           />
         </Col>
       </Row>

--- a/ggircs-app/app/yarn.lock
+++ b/ggircs-app/app/yarn.lock
@@ -7941,7 +7941,7 @@ printj@~1.1.0:
   resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
   integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
-prismjs@1.27.0, prismjs@^1.21.0, prismjs@^1.22.0, prismjs@~1.24.0:
+prismjs@^1.21.0, prismjs@^1.25.0, prismjs@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
   integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
@@ -8278,14 +8278,14 @@ react-syntax-highlighter@^13.5.3:
     refractor "^3.1.0"
 
 react-syntax-highlighter@^15.4.3:
-  version "15.4.4"
-  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.4.4.tgz#dc9043f19e7bd063ff3ea78986d22a6eaa943b2a"
-  integrity sha512-PsOFHNTzkb3OroXdoR897eKN5EZ6grht1iM+f1lJSq7/L0YVnkJaNVwC3wEUYPOAmeyl5xyer1DjL6MrumO6Zw==
+  version "15.4.5"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.4.5.tgz#db900d411d32a65c8e90c39cd64555bf463e712e"
+  integrity sha512-RC90KQTxZ/b7+9iE6s9nmiFLFjWswUcfULi4GwVzdFVKVMQySkJWBuOmJFfjwjMVCo0IUUuJrWebNKyviKpwLQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
     highlight.js "^10.4.1"
     lowlight "^1.17.0"
-    prismjs "^1.22.0"
+    prismjs "^1.25.0"
     refractor "^3.2.0"
 
 react-test-renderer@^17.0.0:
@@ -8403,13 +8403,13 @@ redent@^3.0.0:
     strip-indent "^3.0.0"
 
 refractor@^3.1.0, refractor@^3.2.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.4.0.tgz#62bd274b06c942041f390c371b676eb67cb0a678"
-  integrity sha512-dBeD02lC5eytm9Gld2Mx0cMcnR+zhSnsTfPpWqFaMgUMJfC9A6bcN3Br/NaXrnBJcuxnLFR90k1jrkaSyV8umg==
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.6.0.tgz#ac318f5a0715ead790fcfb0c71f4dd83d977935a"
+  integrity sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==
   dependencies:
     hastscript "^6.0.0"
     parse-entities "^2.0.0"
-    prismjs "~1.24.0"
+    prismjs "~1.27.0"
 
 regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.9"

--- a/ggircs-app/app/yarn.lock
+++ b/ggircs-app/app/yarn.lock
@@ -3077,7 +3077,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-classnames@^2.3.1:
+classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
@@ -3747,6 +3747,11 @@ detect-node@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
+
+diff-match-patch@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
+  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
 
 diff-sequences@^26.6.2:
   version "26.6.2"
@@ -8156,10 +8161,15 @@ react-colorful@^5.1.2:
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.4.0.tgz#e05e602469f9768234f29c1bad9ec1f4e86145a2"
   integrity sha512-k7QJXuQGWevr/V8hoMJ1wBW9i2CVhBdDXpBf3jy/AAtzVyYtsFqEAT+y+NOGiSG1cmnGTreqm5EFLXlVaKbPLQ==
 
-react-diff-view@^2.4.8:
-  version "2.4.8"
-  resolved "https://registry.yarnpkg.com/react-diff-view/-/react-diff-view-2.4.8.tgz#9aa35d337440b0e18537c3a5907f6b36c2efb313"
-  integrity sha512-K9XCaMKzr3aafsxI8sDaLp2EuUv8hZBnoyxDa5eR7HL4ExmhN+Qho78isfotUzp/7j/Omm1PgpNtr45Vi4BIcA==
+react-diff-view@^2.4.10:
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/react-diff-view/-/react-diff-view-2.4.10.tgz#7d38ebd43683f0e506d0d38472c0607e24f30a58"
+  integrity sha512-H9cyh+a002RyP4BMkSaL4OOBDNhkVpaCA+8oHeb6kS3X9Sj8cZymRHf/CyVkTmm+je/qWMa8Po0VBwSnktQ79w==
+  dependencies:
+    classnames "^2.2.6"
+    diff-match-patch "^1.0.5"
+    shallow-equal "^1.2.1"
+    warning "^4.0.2"
 
 react-dom@^17.0.2:
   version "17.0.2"
@@ -8770,6 +8780,11 @@ setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
+shallow-equal@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
+  integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
 shallowequal@^1.1.0:
   version "1.1.0"

--- a/test/data/dev/deploy_data.sh
+++ b/test/data/dev/deploy_data.sh
@@ -42,6 +42,7 @@ _psql() {
 
 deployDevData() {
   _psql -f "./dev_data.sql"
+  _psql -f "./dev_history_data.sql"
   return 0;
 }
 

--- a/test/data/dev/dev_history_data.sql
+++ b/test/data/dev/dev_history_data.sql
@@ -1,0 +1,17 @@
+grant usage on schema swrs_history to ggircs_user;
+grant usage on schema swrs_extract to ggircs_user;
+grant select on all tables in schema swrs_history to ggircs_user;
+grant select on all tables in schema swrs_extract to ggircs_user;
+
+insert into swrs_extract.eccc_zip_file(zip_file_name)
+values ('ZIPPITY_1'), ('DIPPITY_2'), ('BIPPITY_3'), ('ZIPPITY_4');
+
+insert into swrs_extract.eccc_xml_file(xml_file, xml_file_name, zip_file_id)
+values
+('<Report><id>1</id><type>R</type><grade>F</grade><xmen><nightcrawler>true</nightcrawler></xmen></Report>', 'XML REPORT ONE', 1),
+('<Report><id>2</id><type>R</type><grade>F</grade><xmen><nightcrawler>false</nightcrawler></xmen></Report>', 'XML REPORT TWO', 2),
+('<Report><id>1</id><type>R</type><grade>F</grade><xmen><nightcrawler>true</nightcrawler></xmen></Report>', 'XML REPORT THREE', 3),
+('<Report><id>2</id><type>R</type><grade>F</grade><xmen><nightcrawler>false</nightcrawler></xmen></Report>', 'XML REPORT FOUR', 4);
+
+insert into swrs_history.report(id, eccc_xml_file_id, swrs_report_id, submission_date)
+values (1,1,1, now()), (2,2,2, now()), (3,3,3, now()), (4,4,4, now());


### PR DESCRIPTION
Fixing the diffing. The issue was that `useRouter` was being used in 2 components on different branches of the rendering tree, and ordering of some react hooks.

This is because `useRouter` uses React's Context API, which is only unique per branch of the render tree