### PR TITLE
chore: override dependencies in shipit.yaml

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -1,3 +1,6 @@
+dependencies:
+  override: []
+
 deploy:
   override:
     - git submodule update --init --quiet


### PR DESCRIPTION
Shipit introspects your repo and tries to install your dependencies. We don't want to do this when we deploy, everything is handled by `make install`. Overriding the dependencies in shipit.yml should make shipit skip the install dependencies step.