### PR TITLE
chore: tune cluster storage

### DIFF
--- a/helm/cas-ggircs-postgres-cluster/values-prod.yaml
+++ b/helm/cas-ggircs-postgres-cluster/values-prod.yaml
@@ -1,1 +1,4 @@
 environment: prod
+
+postgresCluster:
+  storageSize: 10Gi

--- a/helm/cas-ggircs-postgres-cluster/values-test.yaml
+++ b/helm/cas-ggircs-postgres-cluster/values-test.yaml
@@ -1,1 +1,4 @@
 environment: test
+
+postgresCluster:
+  storageSize: 10Gi


### PR DESCRIPTION
Bumps PGO cluster storage to be in line with legacy Patroni release. 