### PR TITLE
chore: update cif-acccess knp 

### DIFF
--- a/helm/cas-ggircs/templates/networkPolicies/cif-access.yaml
+++ b/helm/cas-ggircs/templates/networkPolicies/cif-access.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      release: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}-db
   ingress:
     - from:
       - namespaceSelector:


### PR DESCRIPTION
The KNP target was not updated after the swap to pg operator. the "release" tag was no longer valid as a selector on the ggircs target service after that update.