### PR TITLE
chore: remove legacy fetch-and-save dag collection method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,14 +210,10 @@ install_pgo_cluster:
 .PHONY: install
 install: whoami install_pgo_cluster
 	@set -euo pipefail; \
-	ggircsDagConfig=$$(echo '{"org": "bcgov", "repo": "cas-ggircs", "ref": "$(GIT_SHA1)", "path": "dags/cas_ggircs_dags.py"}' | base64 -w0); \
-	swrsDagConfig=$$(echo '{"org": "bcgov", "repo": "cas-ggircs", "ref": "$(GIT_SHA1)", "path": "dags/cas_ggircs_swrs_dags.py"}' | base64 -w0); \
 	helm dep up ./helm/cas-ggircs; \
 	helm upgrade --install --atomic --wait-for-jobs --timeout 3600s \
 		--namespace $(GGIRCS_NAMESPACE_PREFIX)-$(ENVIRONMENT) \
 		--set defaultImageTag=$(GIT_SHA1) \
-		--set download-ggircs-dags.dagConfiguration="$$ggircsDagConfig" \
-		--set download-swrs-dags.dagConfiguration="$$swrsDagConfig" \
 		--values ./helm/cas-ggircs/values.yaml \
 		--values ./helm/cas-ggircs/values-$(ENVIRONMENT).yaml \
 		--set ciip.release=cas-ciip-portal \
@@ -244,13 +240,9 @@ lint_chart: $(call make_help,lint_chart,Checks the configured helm chart templat
 lint_chart: whoami
 lint_chart:
 	@set -euo pipefail; \
-	ggircsDagConfig=$$(echo '{"org": "bcgov", "repo": "cas-ggircs", "ref": "$(GIT_SHA1)", "path": "dags/cas_ggircs_dags.py"}' | base64 -w0); \
-	swrsDagConfig=$$(echo '{"org": "bcgov", "repo": "cas-ggircs", "ref": "$(GIT_SHA1)", "path": "dags/cas_ggircs_swrs_dags.py"}' | base64 -w0); \
 	helm dep up ./helm/cas-ggircs; \
 	helm template --validate \
 		--set defaultImageTag=$(GIT_SHA1) \
-		--set download-ggircs-dags.dagConfiguration="$$ggircsDagConfig" \
-		--set download-swrs-dags.dagConfiguration="$$swrsDagConfig" \
 		--values ./helm/cas-ggircs/values.yaml \
 		--values ./helm/cas-ggircs/values-dev.yaml \
 		--set ciip.release=cas-ciip-portal \
@@ -264,8 +256,6 @@ lint_chart:
 		cas-ggircs ./helm/cas-ggircs; \
 	helm template --validate \
 		--set defaultImageTag=$(GIT_SHA1) \
-		--set download-ggircs-dags.dagConfiguration="$$ggircsDagConfig" \
-		--set download-swrs-dags.dagConfiguration="$$swrsDagConfig" \
 		--values ./helm/cas-ggircs/values.yaml \
 		--values ./helm/cas-ggircs/values-test.yaml \
 		--set ciip.release=cas-ciip-portal \
@@ -279,8 +269,6 @@ lint_chart:
 		cas-ggircs ./helm/cas-ggircs; \
 	helm template --validate \
 		--set defaultImageTag=$(GIT_SHA1) \
-		--set download-ggircs-dags.dagConfiguration="$$ggircsDagConfig" \
-		--set download-swrs-dags.dagConfiguration="$$swrsDagConfig" \
 		--values ./helm/cas-ggircs/values.yaml \
 		--values ./helm/cas-ggircs/values-prod.yaml \
 		--set ciip.release=cas-ciip-portal \

--- a/helm/cas-ggircs/Chart.lock
+++ b/helm/cas-ggircs/Chart.lock
@@ -2,14 +2,8 @@ dependencies:
 - name: cas-airflow-dag-trigger
   repository: https://bcgov.github.io/cas-airflow
   version: 1.2.2
-- name: cas-airflow-dag-trigger
-  repository: https://bcgov.github.io/cas-airflow
-  version: 1.2.2
-- name: cas-airflow-dag-trigger
-  repository: https://bcgov.github.io/cas-airflow
-  version: 1.2.2
 - name: terraform-bucket-provision
   repository: https://bcgov.github.io/cas-pipeline/
   version: 0.1.3
-digest: sha256:0fe76f534fb377482be9f4dbbb6489469cc71f549cf9c8bcab5d1c13b4a0ab37
-generated: "2025-12-01T18:25:39.710459-08:00"
+digest: sha256:a8eb9ea0d38b7b7bd2afaa628b23588ffbfb8b17a3d3932ef0a2bdb5d422166e
+generated: "2026-07-17T14:47:15.736876411-06:00"

--- a/helm/cas-ggircs/Chart.yaml
+++ b/helm/cas-ggircs/Chart.yaml
@@ -8,16 +8,6 @@ dependencies:
   - name: cas-airflow-dag-trigger
     version: 1.2.2
     repository: https://bcgov.github.io/cas-airflow
-    alias: download-ggircs-dags
-    condition: download-ggircs-dags.enabled
-  - name: cas-airflow-dag-trigger
-    version: 1.2.2
-    repository: https://bcgov.github.io/cas-airflow
-    alias: download-swrs-dags
-    condition: download-swrs-dags.enabled
-  - name: cas-airflow-dag-trigger
-    version: 1.2.2
-    repository: https://bcgov.github.io/cas-airflow
     alias: trigger-ggircs-deploy-db
     condition: trigger-ggircs-deploy-db.enabled
   - name: terraform-bucket-provision

--- a/helm/cas-ggircs/values-prod.yaml
+++ b/helm/cas-ggircs/values-prod.yaml
@@ -2,12 +2,6 @@ app:
   route:
     host: cas-ggircs.apps.silver.devops.gov.bc.ca
 
-download-ggircs-dags:
-  airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca
-
-download-swrs-dags:
-  airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca
-
 trigger-ggircs-deploy-db:
   airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca
 

--- a/helm/cas-ggircs/values-test.yaml
+++ b/helm/cas-ggircs/values-test.yaml
@@ -2,12 +2,6 @@ app:
   route:
     host: cas-ggircs-test.apps.silver.devops.gov.bc.ca
 
-download-ggircs-dags:
-  airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca
-
-download-swrs-dags:
-  airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca
-
 trigger-ggircs-deploy-db:
   airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca
 

--- a/helm/cas-ggircs/values.yaml
+++ b/helm/cas-ggircs/values.yaml
@@ -82,20 +82,6 @@ app:
   env:
     supportEmail: ggircs@gov.bc.ca
 
-download-ggircs-dags:
-  enabled: true
-  airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca
-  dagId: fetch_and_save_dag_from_github
-  helm:
-    hook: "pre-install,pre-upgrade"
-
-download-swrs-dags:
-  enabled: true
-  airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca
-  dagId: fetch_and_save_dag_from_github
-  helm:
-    hook: "pre-install,pre-upgrade"
-
 trigger-ggircs-deploy-db:
   enabled: true
   airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca


### PR DESCRIPTION
Addresses #4715. Removes legacy method of getting Dags into Airflow, once bcgov/cas-airflow#231 is merged.

## Changes 🚧

- Remove old fetch and save from chart deployments.
chore: remove legacy fetch-and-save dag collection method
